### PR TITLE
Fix equal-segments parsing and add regression test

### DIFF
--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -16,3 +16,13 @@ rules no_solving=true
     out = print_program(dz)
     assert 'segment A-B' in out
     assert 'equal-segments (A-D ; B-C)' in out
+
+
+def test_parse_equal_segments_single_paren():
+    text = "equal-segments (A-B ; C-D)"
+    prog = parse_program(text)
+    assert len(prog.stmts) == 1
+    stmt = prog.stmts[0]
+    assert stmt.kind == 'equal_segments'
+    assert stmt.data['lhs'] == [('A', 'B')]
+    assert stmt.data['rhs'] == [('C', 'D')]


### PR DESCRIPTION
## Summary
- allow the parser to recognize hyphenated keywords and share a single opening parenthesis when parsing equal-segments
- update equal-segments parsing to avoid consuming multiple "(" tokens and reuse the shared helper
- add a regression test that parses a top-level equal-segments statement with one pair of parentheses

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68ccfcca7d2c83238807895a985ca88f