### PR TITLE
Add explicit parallel-edges statement in canonical output

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ segment A-B
 segment B-C
 segment C-D
 segment D-A
-# desugared: A-D ∥ B-C
+parallel-edges (A-D ; B-C)
 equal-segments (A-D ; B-C)
 ```
 

--- a/docs/bnf.txt
+++ b/docs/bnf.txt
@@ -32,6 +32,7 @@ Obj       := 'segment' Pair Opts?
            | 'angle' 'at' ID 'rays' Pair Pair Opts?
            | 'right-angle' 'at' ID 'rays' Pair Pair Opts?
            | 'equal-segments' '(' EdgeList ';' EdgeList ')' Opts?
+           | 'parallel-edges' '(' Pair ';' Pair ')' Opts?
            | 'tangent' 'at' ID 'to' 'circle' 'center' ID Opts?
            | 'line' ID '-' ID 'tangent' 'to' 'circle' 'center' ID 'at' ID Opts?
            | 'polygon' IdChain Opts?

--- a/geoscript_ir/parser.py
+++ b/geoscript_ir/parser.py
@@ -353,6 +353,15 @@ def parse_stmt(tokens: List[Tuple[str, str, int, int]]):
         to, _ = parse_pair(cur)
         opts = parse_opts(cur)
         stmt = Stmt('perpendicular_at', sp, {'at': at, 'to': to}, opts)
+    elif kw == 'parallel-edges':
+        cur.consume_keyword('parallel-edges')
+        cur.expect('LPAREN')
+        edge1, sp = parse_pair(cur)
+        cur.expect('SEMI')
+        edge2, _ = parse_pair(cur)
+        cur.expect('RPAREN')
+        opts = parse_opts(cur)
+        stmt = Stmt('parallel_edges', sp, {'edges': [edge1, edge2]}, opts)
     elif kw == 'parallel':
         cur.consume_keyword('parallel')
         cur.consume_keyword('through')

--- a/geoscript_ir/printer.py
+++ b/geoscript_ir/printer.py
@@ -98,7 +98,9 @@ def print_program(prog: Program) -> str:
         elif s.kind == 'target_arc':
             lines.append(f'target arc {s.data["A"]}-{s.data["B"]} on circle center {s.data["center"]}{o}'); continue
         elif s.kind == 'parallel_edges':
-            a,b = s.data['edges']; lines.append(f'# desugared: {edge_str(a)} ∥ {edge_str(b)}'); continue
+            a, b = s.data['edges']
+            lines.append(f'parallel-edges ({edge_str(a)} ; {edge_str(b)}){o}')
+            continue
         elif s.kind == 'rules':
             parts = [f'{k}={"true" if s.opts[k] else "false"}' for k in sorted(s.opts.keys())]
             lines.append('rules ' + ' '.join(parts)); continue

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -1,0 +1,9 @@
+from geoscript_ir.ast import Program, Span, Stmt
+from geoscript_ir.printer import print_program
+
+
+def test_parallel_edges_prints_canonical_form():
+    stmt = Stmt('parallel_edges', Span(1, 1), {'edges': [('A', 'B'), ('C', 'D')]})
+    prog = Program([stmt])
+
+    assert print_program(prog) == 'parallel-edges (A-B ; C-D)'


### PR DESCRIPTION
## Summary
- add parsing support for `parallel-edges` so parallel constraints have a canonical representation
- update the printer, README example, and BNF documentation to show the new syntax
- cover the printer behaviour with a dedicated unit test

## Testing
- PYTHONPATH=. pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cd1bba1dbc8323ae0124acdf75ca7e