### PR TITLE
Restore canonical BNF text for prompt helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,23 @@ dz = desugar(prog)       # expand square to sides + right angles + equal segment
 print(print_program(dz)) # canonical form
 ```
 
+### Grammar & LLM prompt
+
+The canonical GeoScript grammar lives alongside the library so tooling can
+consume it directly:
+
+```python
+from geoscript_ir.reference import BNF, LLM_PROMPT, get_llm_prompt
+
+print(BNF)                       # raw Backus–Naur form
+print(get_llm_prompt())          # default LLM instructions + BNF
+print(get_llm_prompt(include_bnf=False))  # instructions only
+```
+
+`LLM_PROMPT` is a ready-to-use set of guardrails for agents that need to emit
+GeoScript scenes. It repeats the "do" / "don't" guidance and, by default,
+appends the grammar so the model always has the exact syntax available.
+
 ---
 
 ## Development

--- a/geoscript_ir/__init__.py
+++ b/geoscript_ir/__init__.py
@@ -4,7 +4,9 @@ from .desugar import desugar
 from .consistency import check_consistency
 from .printer import print_program
 from .ast import Program, Stmt, Span
+from .reference import BNF, LLM_PROMPT, get_llm_prompt
+
 __all__ = [
     'parse_program', 'validate', 'ValidationError', 'desugar', 'check_consistency', 'print_program',
-    'Program', 'Stmt', 'Span'
+    'Program', 'Stmt', 'Span', 'BNF', 'LLM_PROMPT', 'get_llm_prompt'
 ]

--- a/geoscript_ir/reference.py
+++ b/geoscript_ir/reference.py
@@ -1,0 +1,157 @@
+"""Reference helpers for the GeoScript intermediate representation."""
+
+from __future__ import annotations
+
+from textwrap import dedent
+
+BNF = dedent(
+    """
+    Program   := { Stmt }
+    Stmt      := Scene | Layout | Points | Obj | Placement | Annot | Target | Rules | Comment
+
+    Scene     := 'scene' STRING
+    Layout    := 'layout' 'canonical=' ID 'scale=' NUMBER
+    Points    := 'points' ID { ',' ID }
+
+    Annot     := 'label point' ID Opts?
+              | 'sidelabel' Pair STRING Opts?
+
+    Target    := 'target'
+                 ( 'angle' 'at' ID 'rays' Pair Pair
+                 | 'length' Pair
+                 | 'point' ID
+                 | 'circle' '(' STRING ')'
+                 | 'area' '(' STRING ')'
+                 | 'arc' ID '-' ID 'on' 'circle' 'center' ID Opts?
+                 )
+
+    Obj       := 'segment' Pair Opts?
+               | 'ray'     Pair Opts?
+               | 'line'    Pair Opts?
+               | 'circle' 'center' ID ('radius-through' ID | 'tangent' '(' EdgeList ')' ) Opts?
+               | 'circle' 'through' '(' IdList ')' Opts?
+               | 'circumcircle' 'of' IdChain Opts?
+               | 'incircle'    'of' IdChain Opts?
+               | 'perpendicular' 'at' ID 'to' Pair Opts?
+               | 'parallel' 'through' ID 'to' Pair Opts?
+               | 'bisector' 'at' ID Opts?
+               | 'median'  'from' ID 'to' Pair Opts?
+               | 'altitude' 'from' ID 'to' Pair Opts?
+               | 'angle' 'at' ID 'rays' Pair Pair Opts?
+               | 'right-angle' 'at' ID 'rays' Pair Pair Opts?
+               | 'equal-segments' '(' EdgeList ';' EdgeList ')' Opts?
+               | 'parallel-edges' '(' Pair ';' Pair ')' Opts?
+               | 'tangent' 'at' ID 'to' 'circle' 'center' ID Opts?
+               | 'line' ID '-' ID 'tangent' 'to' 'circle' 'center' ID 'at' ID Opts?
+               | 'polygon' IdChain Opts?
+               | 'triangle' ID '-' ID '-' ID Opts?
+               | 'quadrilateral' ID '-' ID '-' ID '-' ID Opts?
+               | 'parallelogram' ID '-' ID '-' ID '-' ID Opts?
+               | 'trapezoid' ID '-' ID '-' ID '-' ID Opts?
+               | 'rectangle' ID '-' ID '-' ID '-' ID Opts?
+               | 'square' ID '-' ID '-' ID '-' ID Opts?
+               | 'rhombus' ID '-' ID '-' ID '-' ID Opts?
+
+    Placement := 'point' ID 'on' Path
+               | 'intersect' '(' Path ')' 'with' '(' Path ')' 'at' ID (',' ID)? Opts?
+
+    Path      := 'line'    Pair
+               | 'ray'     Pair
+               | 'segment' Pair
+               | 'circle' 'center' ID
+
+    EdgeList  := Pair { ',' Pair }
+    IdList    := ID { ',' ID }
+    IdChain   := ID '-' ID { '-' ID }
+    Pair      := ID '-' ID
+
+    Opts      := '[' KeyVal { ' ' KeyVal } ']'
+    KeyVal    := KEY '=' (VALUE | STRING)
+    """
+).strip()
+
+_PROMPT_CORE = dedent(
+    """
+    ROLE
+    You are a *Geometry Scene Writer*. Given a concise RU/EN description of a 2D Euclidean geometry task,
+    emit a **GeoScript** program that captures exactly what to draw and how to annotate it. Do **NOT** solve.
+    Do **NOT** invent values. Only encode explicit givens, constructions, constraints, and requested targets.
+
+    OUTPUT CONTRACT
+    - Output **only** GeoScript wrapped in <geoscript> ... </geoscript>. No prose, no code fences, no JSON.
+    - One statement per line; comments start with '#'.
+    - Use ASCII only. Never use the unicode degree symbol (°). Use '^\\circ' in text when needed.
+    - For equations like "AB=4" in the problem text, write:  sidelabel A-B "4"   (no '=' inside quotes).
+
+    PHILOSOPHY
+    - Minimalism: one construct per line, natural verb-first commands.
+    - Declarative givens: list only what the text gives (segments, right angles, parallels, circles, tangents, etc.).
+    - Constraints (no solving): tell where points lie or how paths meet using 'point ... on ...' and 'intersect ... with ...'.
+    - Annotations as needed for rendering: point labels, side labels, optional style/measure hints.
+    - Targets describe "what to find" without solving.
+
+    -----------------------------------------
+    CIRCLE / INSCRIBED / CIRCUMSCRIBED LOGIC
+    -----------------------------------------
+    You MUST add a circle statement whenever the text implies one of the following:
+
+    A) Polygon inscribed in a circle (RU: "многоугольник … вписан в окружность", e.g., "Четырёхугольник ABCD вписан в окружность";
+       EN: "polygon ABCD is inscribed in a circle", "cyclic quadrilateral ABCD"):
+        → Include the polygon sides and
+        → Add:  circle through (A, B, C, D)    # 3+ points; list all named vertices if convenient
+           (If only a triangle is mentioned as cyclic, you can use: circle through (A, B, C) or: circumcircle of A-B-C)
+
+    B) Circumcircle of a triangle (RU: "окружность, описанная около △ABC", "описанная окружность ABC";
+       EN: "circumcircle of triangle ABC"):
+        → Add:  circumcircle of A-B-C
+           (or equivalently: circle through (A, B, C))
+
+    C) Incircle of a triangle (RU: "вписанная окружность △ABC"; EN: "incircle of triangle ABC"):
+        → Prefer:  incircle of A-B-C
+           (or, if a center I is explicitly named, you may write:
+            circle center I tangent (A-B, B-C, C-A) [label="incircle"])
+        Do NOT invent center points if they are not named.
+
+    D) Polygon circumscribed about a circle (RU: "многоугольник, описанный около окружности"):
+        → Add the circle and tangency to all sides given, e.g.:
+           circle tangent (A-B, B-C, C-D, D-A)
+
+    Notes:
+    - "Cyclic quadrilateral" means vertices lie on one circle ⇒ use (A).
+    - If a circle is implicit by wording, include it even if the word "circle/окружность" is not repeated later.
+    - If both a circle and its center are explicitly named, include the center as a point label if asked; otherwise it can be omitted.
+
+    Authoring DOs:
+    - Include a **circle** whenever the text says cyclic/inscribed/circumscribed per the rules above.
+    - For cyclic quadrilateral/triangle: use `circle through (...)` (or `circumcircle of A-B-C` for triangles).
+    - For triangle incircle: use `incircle of A-B-C`. If a center is named (I), you may instead use tangency form with center.
+    - For phrases like "отрезок CO пересекает окружность в точке B", encode the intersection explicitly:
+      either (a) two placements: `point B on circle center O` + `point B on ray C-O`, or
+      (b) one line: `intersect (ray C-O) with (circle center O) at B [choose=near C]`.
+    - For "касается (tangent)", add `tangent at A to circle center O`. If a specific line is named, you may also assert
+      `line C-A tangent to circle center O at A`. (A right-angle mark with AO is optional.)
+    - For "дуга AB внутри угла ACO", use `target arc A-B on circle center O [inside_at=C]`.
+    - If a longest side is stated or triangle named, choose an appropriate layout canonical (triangle_AB_horizontal, etc.).
+    - For right angles, prefer a 'right-angle' statement with [mark=square].
+    - Use 'sidelabel' for numeric side text **without '='**; use 'label point' for point labels.
+
+    Authoring DON'Ts:
+    - Don't compute or guess any value or coordinate.
+    - Don't introduce auxiliary constructions unless the text explicitly allows it (then set rules allow_auxiliary=true).
+    - Don't output prose, Markdown code fences, JSON, or unicode degree (°).
+    - Don't write unicode √ or "sqrt(...)" in labels; prefer LaTeX macros like \\sqrt{...}.
+    """
+).strip()
+
+
+def get_llm_prompt(*, include_bnf: bool = True) -> str:
+    """Return the standard GeometryIR prompt for LLM agents."""
+    sections = [_PROMPT_CORE]
+    if include_bnf:
+        sections.append("SYNTAX REFERENCE (BNF)\n" + BNF)
+    return "\n\n".join(sections)
+
+
+LLM_PROMPT = get_llm_prompt()
+
+__all__ = ["BNF", "LLM_PROMPT", "get_llm_prompt"]

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+from geoscript_ir.reference import BNF, LLM_PROMPT, get_llm_prompt
+
+
+def test_bnf_matches_docs():
+    docs_path = Path(__file__).resolve().parents[1] / "docs" / "bnf.txt"
+    assert docs_path.exists(), "expected docs/bnf.txt to exist"
+    assert BNF == docs_path.read_text(encoding="utf-8").strip()
+
+
+def test_prompt_includes_bnf_by_default():
+    prompt = LLM_PROMPT
+    assert "SYNTAX REFERENCE (BNF)" in prompt
+    assert BNF in prompt
+    assert prompt.count("<geoscript>") == 1
+    assert prompt.count("</geoscript>") == 1
+
+
+def test_prompt_can_skip_bnf():
+    prompt = get_llm_prompt(include_bnf=False)
+    assert "SYNTAX REFERENCE" not in prompt
+    assert BNF not in prompt


### PR DESCRIPTION
## Summary
- restore `docs/bnf.txt` to the canonical grammar used by the parser stack
- align the packaged `BNF` helper with the reverted grammar so prompt helpers stay consistent

## Testing
- PYTHONPATH=. pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cd251988dc8323b4766099cc272fda