### PR TITLE
Add SciPy least-squares solver pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,36 @@ dz = desugar(prog)       # expand square to sides + right angles + equal segment
 print(print_program(dz)) # canonical form
 ```
 
+### Numeric solver (GeometryIR → SciPy)
+
+The `geoscript_ir.solver` module compiles validated GeoScript into a
+numeric model and optimizes the residuals with `scipy.optimize.least_squares`.
+
+```python
+from geoscript_ir import parse_program, validate, desugar
+from geoscript_ir.solver import translate, solve, SolveOptions
+
+text = """
+scene "Right triangle"
+points A, B, C
+segment A-B [length=4]
+segment A-C [length=3]
+segment B-C [length=5]
+right-angle at A rays A-B A-C
+"""
+
+program = parse_program(text)
+validate(program)
+desugared = desugar(program)
+model = translate(desugared)
+solution = solve(model, SolveOptions())
+
+print(solution.success, solution.max_residual)
+print(solution.point_coords)
+```
+
+See `examples/solve_right_triangle.py` for a complete runnable sample.
+
 ### Grammar & LLM prompt
 
 The canonical GeoScript grammar lives alongside the library so tooling can

--- a/examples/solve_right_triangle.py
+++ b/examples/solve_right_triangle.py
@@ -1,0 +1,29 @@
+"""Example pipeline: parse GeoScript and solve coordinates numerically."""
+
+from geoscript_ir import parse_program, validate, desugar
+from geoscript_ir.solver import translate, solve, SolveOptions
+
+TEXT = """
+scene "Right triangle"
+points A, B, C
+segment A-B [length=4]
+segment A-C [length=3]
+segment B-C [length=5]
+right-angle at A rays A-B A-C
+"""
+
+
+def main() -> None:
+    program = parse_program(TEXT)
+    validate(program)
+    desugared = desugar(program)
+    model = translate(desugared)
+    solution = solve(model, SolveOptions(random_seed=123, reseed_attempts=1))
+    print("Success:", solution.success)
+    print("Max residual:", solution.max_residual)
+    for name, (x, y) in solution.point_coords.items():
+        print(f"{name}: ({x:.6f}, {y:.6f})")
+
+
+if __name__ == "__main__":
+    main()

--- a/geoscript_ir/__init__.py
+++ b/geoscript_ir/__init__.py
@@ -5,8 +5,16 @@ from .consistency import check_consistency
 from .printer import print_program
 from .ast import Program, Stmt, Span
 from .reference import BNF, LLM_PROMPT, get_llm_prompt
+from .solver import (
+    translate,
+    solve,
+    SolveOptions,
+    Model,
+    Solution,
+)
 
 __all__ = [
     'parse_program', 'validate', 'ValidationError', 'desugar', 'check_consistency', 'print_program',
+    'translate', 'solve', 'SolveOptions', 'Model', 'Solution',
     'Program', 'Stmt', 'Span', 'BNF', 'LLM_PROMPT', 'get_llm_prompt'
 ]

--- a/geoscript_ir/solver.py
+++ b/geoscript_ir/solver.py
@@ -1,0 +1,499 @@
+from __future__ import annotations
+
+"""Numeric solver pipeline for GeometryIR scenes."""
+
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Optional, Sequence, Tuple
+import math
+
+import numpy as np
+from scipy.optimize import least_squares
+
+from .ast import Program, Stmt
+
+PointName = str
+Edge = Tuple[str, str]
+ResidualFunc = Callable[[np.ndarray], np.ndarray]
+
+
+@dataclass
+class ResidualSpec:
+    """Container describing one residual block."""
+
+    key: str
+    func: ResidualFunc
+    size: int
+    kind: str
+    source: Optional[Stmt] = None
+
+
+@dataclass
+class Model:
+    """Numeric model compiled from GeometryIR."""
+
+    points: List[PointName]
+    index: Dict[PointName, int]
+    residuals: List[ResidualSpec]
+    gauges: List[str] = field(default_factory=list)
+
+
+@dataclass
+class SolveOptions:
+    method: str = "trf"
+    loss: str = "linear"
+    max_nfev: int = 2000
+    tol: float = 1e-8
+    reseed_attempts: int = 3
+    random_seed: Optional[int] = 0
+
+
+@dataclass
+class Solution:
+    point_coords: Dict[PointName, Tuple[float, float]]
+    success: bool
+    max_residual: float
+    residual_breakdown: List[Dict[str, object]]
+    warnings: List[str]
+
+
+def _register_point(order: List[PointName], seen: Dict[PointName, int], name: PointName) -> None:
+    if name not in seen:
+        seen[name] = len(order)
+        order.append(name)
+
+
+def _format_edge(edge: Edge) -> str:
+    return f"{edge[0]}-{edge[1]}"
+
+
+def _vec(x: np.ndarray, index: Dict[PointName, int], p: PointName) -> np.ndarray:
+    base = index[p] * 2
+    return x[base : base + 2]
+
+
+def _edge_vec(x: np.ndarray, index: Dict[PointName, int], edge: Edge) -> np.ndarray:
+    return _vec(x, index, edge[1]) - _vec(x, index, edge[0])
+
+
+def _norm_sq(vec: np.ndarray) -> float:
+    return float(np.dot(vec, vec))
+
+
+def _cross_2d(a: np.ndarray, b: np.ndarray) -> float:
+    return float(a[0] * b[1] - a[1] * b[0])
+
+
+def _build_segment_length(stmt: Stmt, index: Dict[PointName, int]) -> List[ResidualSpec]:
+    length = stmt.opts.get("length") or stmt.opts.get("distance") or stmt.opts.get("value")
+    if length is None:
+        return []
+    value = float(length)
+    edge = tuple(stmt.data["edge"])  # type: ignore[arg-type]
+
+    def func(x: np.ndarray) -> np.ndarray:
+        vec = _edge_vec(x, index, edge)
+        return np.array([_norm_sq(vec) - value**2], dtype=float)
+
+    key = f"segment_length({_format_edge(edge)})"
+    return [ResidualSpec(key=key, func=func, size=1, kind="segment_length", source=stmt)]
+
+
+def _build_equal_segments(stmt: Stmt, index: Dict[PointName, int]) -> List[ResidualSpec]:
+    lhs: Sequence[Edge] = [tuple(e) for e in stmt.data.get("lhs", [])]
+    rhs: Sequence[Edge] = [tuple(e) for e in stmt.data.get("rhs", [])]
+    segments: List[Edge] = list(lhs) + list(rhs)
+    if len(segments) <= 1:
+        return []
+    ref = segments[0]
+    others = segments[1:]
+
+    def func(x: np.ndarray) -> np.ndarray:
+        ref_len = _norm_sq(_edge_vec(x, index, ref))
+        vals = [
+            _norm_sq(_edge_vec(x, index, seg)) - ref_len
+            for seg in others
+        ]
+        return np.asarray(vals, dtype=float)
+
+    key = "equal_segments(" + ",".join(_format_edge(e) for e in segments) + ")"
+    return [ResidualSpec(key=key, func=func, size=len(others), kind="equal_segments", source=stmt)]
+
+
+def _build_parallel_edges(stmt: Stmt, index: Dict[PointName, int]) -> List[ResidualSpec]:
+    edges: Sequence[Edge] = [tuple(e) for e in stmt.data.get("edges", [])]
+    if len(edges) <= 1:
+        return []
+    ref = edges[0]
+    others = edges[1:]
+
+    def func(x: np.ndarray) -> np.ndarray:
+        ref_vec = _edge_vec(x, index, ref)
+        vals = [
+            _cross_2d(ref_vec, _edge_vec(x, index, edge))
+            for edge in others
+        ]
+        return np.asarray(vals, dtype=float)
+
+    key = "parallel_edges(" + ",".join(_format_edge(e) for e in edges) + ")"
+    return [ResidualSpec(key=key, func=func, size=len(others), kind="parallel_edges", source=stmt)]
+
+
+def _build_right_angle(stmt: Stmt, index: Dict[PointName, int]) -> List[ResidualSpec]:
+    (ray1, ray2) = stmt.data["rays"]
+    ray1 = tuple(ray1)
+    ray2 = tuple(ray2)
+    at = stmt.data["at"]
+
+    def func(x: np.ndarray) -> np.ndarray:
+        u = _edge_vec(x, index, ray1)
+        v = _edge_vec(x, index, ray2)
+        return np.array([float(np.dot(u, v))], dtype=float)
+
+    key = f"right_angle({at})"
+    return [ResidualSpec(key=key, func=func, size=1, kind="right_angle", source=stmt)]
+
+
+def _build_angle(stmt: Stmt, index: Dict[PointName, int]) -> List[ResidualSpec]:
+    measure = stmt.opts.get("measure") or stmt.opts.get("degrees")
+    if measure is None:
+        return []
+    theta = float(measure)
+    (ray1, ray2) = stmt.data["rays"]
+    ray1 = tuple(ray1)
+    ray2 = tuple(ray2)
+    at = stmt.data["at"]
+
+    cos_target = math.cos(math.radians(theta))
+
+    def func(x: np.ndarray) -> np.ndarray:
+        u = _edge_vec(x, index, ray1)
+        v = _edge_vec(x, index, ray2)
+        nu = math.sqrt(max(_norm_sq(u), 1e-16))
+        nv = math.sqrt(max(_norm_sq(v), 1e-16))
+        cos_val = float(np.dot(u, v)) / (nu * nv)
+        return np.array([cos_val - cos_target], dtype=float)
+
+    key = f"angle({at})={theta}"
+    return [ResidualSpec(key=key, func=func, size=1, kind="angle", source=stmt)]
+
+
+def _as_edge(value: object) -> Edge:
+    if isinstance(value, (list, tuple)) and len(value) == 2:
+        return (value[0], value[1])  # type: ignore[return-value]
+    raise ValueError(f"expected edge, got {value!r}")
+
+
+def _build_point_on(stmt: Stmt, index: Dict[PointName, int]) -> List[ResidualSpec]:
+    point = stmt.data["point"]
+    path_kind, payload = stmt.data["path"]
+
+    if path_kind in {"line", "segment", "ray"}:
+        edge = _as_edge(payload)
+
+        def func(x: np.ndarray) -> np.ndarray:
+            base = _vec(x, index, edge[0])
+            dir_vec = _edge_vec(x, index, edge)
+            pt = _vec(x, index, point)
+            return np.array([_cross_2d(dir_vec, pt - base)], dtype=float)
+
+        key = f"point_on_{path_kind}({point},{_format_edge(edge)})"
+        return [ResidualSpec(key=key, func=func, size=1, kind=f"point_on_{path_kind}", source=stmt)]
+
+    if path_kind == "circle":
+        radius = stmt.opts.get("radius") or stmt.opts.get("distance")
+        if radius is None:
+            raise ValueError("point on circle requires numeric radius in options")
+        if not isinstance(payload, str):
+            raise ValueError("circle payload must be center point name")
+        center = payload
+        r_val = float(radius)
+
+        def func(x: np.ndarray) -> np.ndarray:
+            vec = _vec(x, index, point) - _vec(x, index, center)
+            return np.array([_norm_sq(vec) - r_val**2], dtype=float)
+
+        key = f"point_on_circle({point},{center})"
+        return [ResidualSpec(key=key, func=func, size=1, kind="point_on_circle", source=stmt)]
+
+    raise ValueError(f"Unsupported path kind for point_on: {path_kind}")
+
+
+def _build_collinear(stmt: Stmt, index: Dict[PointName, int]) -> List[ResidualSpec]:
+    pts: Sequence[PointName] = stmt.data.get("points", [])
+    if len(pts) < 3:
+        return []
+    p0 = pts[0]
+    others = pts[1:]
+
+    def func(x: np.ndarray) -> np.ndarray:
+        base = _vec(x, index, p0)
+        base_dir = _vec(x, index, others[0]) - base
+        vals = [
+            _cross_2d(base_dir, _vec(x, index, pt) - base)
+            for pt in others[1:]
+        ]
+        return np.asarray(vals, dtype=float)
+
+    key = "collinear(" + ",".join(pts) + ")"
+    return [ResidualSpec(key=key, func=func, size=len(others) - 1, kind="collinear", source=stmt)]
+
+
+def _build_midpoint(stmt: Stmt, index: Dict[PointName, int]) -> List[ResidualSpec]:
+    midpoint = stmt.data["midpoint"]
+    edge = tuple(stmt.data["edge"])
+
+    def func(x: np.ndarray) -> np.ndarray:
+        mid = _vec(x, index, midpoint)
+        b = _vec(x, index, edge[0])
+        c = _vec(x, index, edge[1])
+        return 2 * mid - (b + c)
+
+    key = f"midpoint({midpoint},{_format_edge(edge)})"
+    return [ResidualSpec(key=key, func=func, size=2, kind="midpoint", source=stmt)]
+
+
+def _build_foot(stmt: Stmt, index: Dict[PointName, int]) -> List[ResidualSpec]:
+    foot = stmt.data["foot"]
+    vertex = stmt.data["from"]
+    edge = tuple(stmt.data["edge"])
+
+    def func(x: np.ndarray) -> np.ndarray:
+        a = _vec(x, index, edge[0])
+        b = _vec(x, index, edge[1])
+        h = _vec(x, index, foot)
+        c = _vec(x, index, vertex)
+        ab = b - a
+        return np.array([
+            _cross_2d(ab, h - a),
+            float(np.dot(c - h, ab))
+        ], dtype=float)
+
+    key = f"foot({vertex}->{foot} on {_format_edge(edge)})"
+    return [ResidualSpec(key=key, func=func, size=2, kind="foot", source=stmt)]
+
+
+def _build_distance(stmt: Stmt, index: Dict[PointName, int]) -> List[ResidualSpec]:
+    raw = stmt.data.get("points") or stmt.data.get("edge")
+    if raw is None:
+        raise ValueError("distance constraint missing point pair")
+    pts = _as_edge(raw)
+    if len(pts) != 2:
+        raise ValueError("distance constraint requires exactly two points")
+    value = stmt.data.get("value") or stmt.opts.get("value")
+    if value is None:
+        raise ValueError("distance constraint missing numeric value")
+    dist = float(value)
+
+    def func(x: np.ndarray) -> np.ndarray:
+        vec = _edge_vec(x, index, pts)  # type: ignore[arg-type]
+        return np.array([_norm_sq(vec) - dist**2], dtype=float)
+
+    key = f"distance({_format_edge(pts)})={dist}"
+    return [ResidualSpec(key=key, func=func, size=1, kind="distance", source=stmt)]
+
+
+_RESIDUAL_BUILDERS: Dict[str, Callable[[Stmt, Dict[PointName, int]], List[ResidualSpec]]] = {
+    "segment": _build_segment_length,
+    "equal_segments": _build_equal_segments,
+    "parallel_edges": _build_parallel_edges,
+    "right_angle_at": _build_right_angle,
+    "angle_at": _build_angle,
+    "point_on": _build_point_on,
+    "collinear": _build_collinear,
+    "midpoint": _build_midpoint,
+    "foot": _build_foot,
+    "distance": _build_distance,
+}
+
+
+def translate(program: Program) -> Model:
+    """Translate a validated GeometryIR program into a numeric model."""
+
+    order: List[PointName] = []
+    seen: Dict[PointName, int] = {}
+    orientation_edge: Optional[Edge] = None
+
+    def handle_edge(edge: Sequence[str]) -> None:
+        nonlocal orientation_edge
+        a, b = edge[0], edge[1]
+        _register_point(order, seen, a)
+        _register_point(order, seen, b)
+        if orientation_edge is None and a != b:
+            orientation_edge = (a, b)
+
+    for stmt in program.stmts:
+        if stmt.kind == "points":
+            for name in stmt.data.get("ids", []):
+                _register_point(order, seen, name)
+            continue
+        data = stmt.data
+        if "point" in data and isinstance(data["point"], str):
+            _register_point(order, seen, data["point"])
+        if "points" in data:
+            for name in data["points"]:
+                _register_point(order, seen, name)
+        if "edge" in data:
+            handle_edge(data["edge"])
+        if "edges" in data:
+            for edge in data["edges"]:
+                handle_edge(edge)
+        if "rays" in data:
+            for ray in data["rays"]:
+                handle_edge(ray)
+        if "path" in data:
+            kind, payload = data["path"]
+            if kind in {"line", "segment", "ray"}:
+                handle_edge(payload)
+            elif kind == "circle" and isinstance(payload, str):
+                _register_point(order, seen, payload)
+        if "midpoint" in data:
+            _register_point(order, seen, data["midpoint"])
+        if "foot" in data:
+            _register_point(order, seen, data["foot"])
+        if "from" in data and isinstance(data["from"], str):
+            _register_point(order, seen, data["from"])
+
+    if not order:
+        raise ValueError("program contains no points to solve for")
+
+    index = {name: i for i, name in enumerate(order)}
+    residuals: List[ResidualSpec] = []
+
+    for stmt in program.stmts:
+        builder = _RESIDUAL_BUILDERS.get(stmt.kind)
+        if not builder:
+            continue
+        built = builder(stmt, index)
+        residuals.extend(built)
+
+    gauges: List[str] = []
+
+    anchor_point = order[0]
+
+    def anchor_func(x: np.ndarray) -> np.ndarray:
+        base = index[anchor_point] * 2
+        return x[base : base + 2]
+
+    residuals.append(
+        ResidualSpec(
+            key=f"gauge:anchor({anchor_point})",
+            func=anchor_func,
+            size=2,
+            kind="gauge",
+            source=None,
+        )
+    )
+    gauges.append(f"anchor={anchor_point}")
+
+    if orientation_edge is not None:
+        a, b = orientation_edge
+
+        def orient_func(x: np.ndarray) -> np.ndarray:
+            a_y = _vec(x, index, a)[1]
+            b_y = _vec(x, index, b)[1]
+            return np.array([b_y - a_y], dtype=float)
+
+        residuals.append(
+            ResidualSpec(
+                key=f"gauge:orientation({_format_edge(orientation_edge)})",
+                func=orient_func,
+                size=1,
+                kind="gauge",
+                source=None,
+            )
+        )
+        gauges.append(f"orientation={_format_edge(orientation_edge)}")
+
+    return Model(points=order, index=index, residuals=residuals, gauges=gauges)
+
+
+def _initial_guess(model: Model, rng: np.random.Generator) -> np.ndarray:
+    guess = rng.uniform(-0.5, 0.5, size=2 * len(model.points))
+    return guess
+
+
+def _evaluate(model: Model, x: np.ndarray) -> Tuple[np.ndarray, List[Tuple[ResidualSpec, np.ndarray]]]:
+    blocks: List[np.ndarray] = []
+    breakdown: List[Tuple[ResidualSpec, np.ndarray]] = []
+    for spec in model.residuals:
+        vals = spec.func(x)
+        vals = np.atleast_1d(np.asarray(vals, dtype=float))
+        if vals.shape[0] != spec.size:
+            raise ValueError(f"Residual {spec.key} expected size {spec.size}, got {vals.shape[0]}")
+        blocks.append(vals)
+        breakdown.append((spec, vals))
+    if blocks:
+        return np.concatenate(blocks), breakdown
+    return np.zeros(0, dtype=float), breakdown
+
+
+def solve(model: Model, options: SolveOptions = SolveOptions()) -> Solution:
+    rng = np.random.default_rng(options.random_seed)
+    warnings: List[str] = []
+    best_result: Optional[Tuple[float, np.ndarray, List[Tuple[ResidualSpec, np.ndarray]], bool]] = None
+
+    for attempt in range(max(1, options.reseed_attempts)):
+        x0 = _initial_guess(model, rng)
+
+        def fun(x: np.ndarray) -> np.ndarray:
+            vals, _ = _evaluate(model, x)
+            return vals
+
+        result = least_squares(
+            fun,
+            x0,
+            method=options.method,
+            loss=options.loss,
+            max_nfev=options.max_nfev,
+            ftol=options.tol,
+            xtol=options.tol,
+            gtol=options.tol,
+        )
+        vals, breakdown = _evaluate(model, result.x)
+        max_res = float(np.max(np.abs(vals))) if vals.size else 0.0
+        converged = bool(result.success and max_res <= options.tol)
+
+        if best_result is None or max_res < best_result[0]:
+            best_result = (max_res, result.x, breakdown, converged)
+
+        if converged:
+            break
+
+        if attempt < options.reseed_attempts - 1:
+            warnings.append(
+                f"reseed attempt {attempt + 2} after residual max {max_res:.3e}"
+            )
+
+    if best_result is None:
+        raise RuntimeError("solver failed to evaluate residuals")
+
+    max_res, best_x, breakdown, converged = best_result
+    if not converged:
+        warnings.append(
+            f"solver did not converge within tolerance {options.tol:.1e}; max residual {max_res:.3e}"
+        )
+
+    coords: Dict[PointName, Tuple[float, float]] = {}
+    for name in model.points:
+        idx = model.index[name] * 2
+        coords[name] = (float(best_x[idx]), float(best_x[idx + 1]))
+
+    breakdown_info: List[Dict[str, object]] = []
+    for spec, values in breakdown:
+        breakdown_info.append(
+            {
+                "key": spec.key,
+                "kind": spec.kind,
+                "values": values.tolist(),
+                "max_abs": float(np.max(np.abs(values))) if values.size else 0.0,
+                "source_kind": spec.source.kind if spec.source else None,
+            }
+        )
+
+    return Solution(
+        point_coords=coords,
+        success=converged,
+        max_residual=max_res,
+        residual_breakdown=breakdown_info,
+        warnings=warnings,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,10 @@ name = "geoscript-ir"
 version = "0.1.0"
 description = "GeoScript parser, validator, and desugarer"
 requires-python = ">=3.8"
+dependencies = [
+    "numpy>=1.24",
+    "scipy>=1.10",
+]
 
 [project.optional-dependencies]
 test = [

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -1,0 +1,82 @@
+import numpy as np
+import pytest
+
+from geoscript_ir import parse_program, validate, desugar
+from geoscript_ir.solver import translate, solve, SolveOptions
+
+
+def _build_model(text: str):
+    prog = parse_program(text)
+    validate(prog)
+    dz = desugar(prog)
+    return translate(dz)
+
+
+def test_translate_adds_gauges_and_residuals():
+    model = _build_model(
+        """
+        scene "Right triangle"
+        points A, B, C
+        segment A-B [length=4]
+        segment A-C [length=3]
+        segment B-C [length=5]
+        right-angle at A rays A-B A-C
+        """
+    )
+    assert model.points == ["A", "B", "C"]
+    assert any(spec.kind == "segment_length" for spec in model.residuals)
+    assert any(spec.kind == "right_angle" for spec in model.residuals)
+    assert any(g.startswith("anchor=") for g in model.gauges)
+    assert any(g.startswith("orientation=") for g in model.gauges)
+
+
+def test_solver_right_triangle_solution_is_stable():
+    model = _build_model(
+        """
+        scene "Right triangle"
+        points A, B, C
+        segment A-B [length=4]
+        segment A-C [length=3]
+        segment B-C [length=5]
+        right-angle at A rays A-B A-C
+        """
+    )
+    opts = SolveOptions(random_seed=1234, reseed_attempts=1)
+    sol1 = solve(model, opts)
+    sol2 = solve(model, opts)
+
+    assert sol1.success
+    assert sol1.max_residual <= 1e-6
+    assert sol2.success
+    assert sol2.max_residual == pytest.approx(sol1.max_residual, abs=1e-9)
+    for name in model.points:
+        assert sol2.point_coords[name] == pytest.approx(sol1.point_coords[name], abs=1e-9)
+
+    coords = sol1.point_coords
+    a = np.array(coords["A"])
+    b = np.array(coords["B"])
+    c = np.array(coords["C"])
+
+    assert np.linalg.norm(a) <= 1e-8
+    assert abs(b[1]) <= 1e-6
+    assert pytest.approx(16.0, rel=1e-6) == np.dot(b - a, b - a)
+    assert pytest.approx(9.0, rel=1e-6) == np.dot(c - a, c - a)
+    assert pytest.approx(25.0, rel=1e-6) == np.dot(c - b, c - b)
+
+
+def test_solver_reports_failure_for_inconsistent_constraints():
+    model = _build_model(
+        """
+        scene "Degenerate"
+        points A, B
+        segment A-B [length=1]
+        segment A-B [length=2]
+        """
+    )
+    opts = SolveOptions(random_seed=42, reseed_attempts=2, max_nfev=1000)
+    sol = solve(model, opts)
+
+    assert not sol.success
+    assert sol.max_residual > 1e-4
+    assert any("did not converge" in msg for msg in sol.warnings)
+    assert len(sol.residual_breakdown) >= 1


### PR DESCRIPTION
## Summary
- add a GeometryIR-to-residual translator and SciPy-based `solve` wrapper, including gauge handling and diagnostics
- expose the solver API, document it in the README, and provide a runnable right-triangle example
- require numpy/scipy at install time and cover the pipeline with new solver-focused pytest cases

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cd374aa5608323a909bcc272327d74