### PR TITLE
Desugar circle forms into primitive constraints

### DIFF
--- a/examples/solve_circle.py
+++ b/examples/solve_circle.py
@@ -1,0 +1,58 @@
+"""Example pipeline: parse GeoScript and solve coordinates numerically."""
+
+from geoscript_ir import parse_program, validate, desugar, print_program
+from geoscript_ir.solver import translate, solve, SolveOptions
+
+TEXT = """
+# Отрезки $AB$ и $CD$ — диаметры окружности с центром $О$. Найдите периметр треугольника $AOD$, если известно, что $СВ = 13$ см, $AB = 16$ см.
+# --- Геометрическая постановка задачи ---
+scene "Circle"
+layout canonical=euclid scale=1
+points A, B, C, D, O
+
+# Окружность с центром O
+circle center O radius-through A
+equal-segments ( O-A , O-B; O-C, O-D )
+
+# Диаметры: центр лежит на прямых AB и CD
+point O on line A-B
+point O on line C-D
+
+# Треугольник интереса
+triangle A-O-D
+
+# Данные (аннотации длин)
+segment C-B [length=4]
+segment A-B [length=16]
+
+# Цели (для периметра P(AOD) = AO + OD + AD)
+target length A-O
+target length O-D
+target length A-D
+
+"""
+
+
+def main() -> None:
+    program = parse_program(TEXT)
+    validate(program)
+    desugared = desugar(program)
+    print(f"Desugared:\n{print_program(desugared)}")
+
+    model = translate(desugared)
+    print("Model:")
+    print(f"  Points: {model.points}")
+    print(f"  Gauges: {model.gauges}")
+    print(f"  Residuals ({len(model.residuals)}):")
+    for i, residual in enumerate(model.residuals):
+        print(f"    [{i}] {residual.key} (size={residual.size}, kind={residual.kind})")
+    solution = solve(model, SolveOptions(random_seed=123, reseed_attempts=1))
+
+    print("\nSolved\nSuccess:", solution.success)
+    print("Max residual:", solution.max_residual)
+    for name, (x, y) in solution.point_coords.items():
+        print(f"{name}: ({x:.6f}, {y:.6f})")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_desugar.py
+++ b/tests/test_desugar.py
@@ -117,3 +117,136 @@ def test_rhombus_equal_segments_cover_all_sides():
     equal_segments = [s for s in out.stmts if s.kind == 'equal_segments' and s.origin == 'desugar(rhombus)']
     assert len(equal_segments) == 1
     assert equal_segments[0].data == {'lhs': [('A', 'B')], 'rhs': [('B', 'C'), ('C', 'D'), ('D', 'A')]}
+
+
+def test_circle_tangent_edges_expand_to_intersections_and_right_angles():
+    circle = stmt(
+        'circle_center_tangent_sides',
+        {'center': 'O', 'tangent_edges': [('A', 'B'), ('C', 'D')]},
+        {'mark': 'incircle'},
+    )
+
+    out = desugar(Program([circle]))
+
+    intersects = [
+        s
+        for s in out.stmts
+        if s.kind == 'intersect' and s.origin == 'desugar(circle_center_tangent_sides)'
+    ]
+    assert {s.data['at'] for s in intersects} == {'T_AB', 'T_CD'}
+    for stmt_inter in intersects:
+        if stmt_inter.data['at'] == 'T_AB':
+            assert stmt_inter.data['path1'] == ('line', ('A', 'B'))
+        else:
+            assert stmt_inter.data['path1'] == ('line', ('C', 'D'))
+        assert stmt_inter.data['path2'] == ('circle', 'O')
+        assert stmt_inter.data['at2'] is None
+        assert stmt_inter.opts == {'mark': 'incircle'}
+
+    right_angles = [
+        s
+        for s in out.stmts
+        if s.kind == 'right_angle_at' and s.origin == 'desugar(circle_center_tangent_sides)'
+    ]
+    assert {s.data['at'] for s in right_angles} == {'T_AB', 'T_CD'}
+    assert all(s.opts == {} for s in right_angles)
+
+
+def test_circle_through_creates_center_and_equal_radii():
+    circle = stmt('circle_through', {'ids': ['A', 'B', 'C', 'D']}, {'label': 'omega'})
+
+    out = desugar(Program([circle]))
+
+    centers = [
+        s
+        for s in out.stmts
+        if s.kind == 'circle_center_radius_through' and s.origin == 'desugar(circle_through)'
+    ]
+    assert len(centers) == 1
+    assert centers[0].data == {'center': 'O_ABC', 'through': 'A'}
+    assert centers[0].opts == {'label': 'omega'}
+
+    eqs = [
+        s
+        for s in out.stmts
+        if s.kind == 'equal_segments' and s.origin == 'desugar(circle_through)'
+    ]
+    assert len(eqs) == 1
+    assert eqs[0].data == {
+        'lhs': [('O_ABC', 'A')],
+        'rhs': [('O_ABC', 'B'), ('O_ABC', 'C'), ('O_ABC', 'D')],
+    }
+
+
+def test_circumcircle_matches_circle_pattern():
+    circle = stmt('circumcircle', {'ids': ['A', 'B', 'C', 'E']})
+
+    out = desugar(Program([circle]))
+
+    centers = [
+        s
+        for s in out.stmts
+        if s.kind == 'circle_center_radius_through' and s.origin == 'desugar(circumcircle)'
+    ]
+    assert len(centers) == 1
+    assert centers[0].data == {'center': 'O_ABC', 'through': 'A'}
+
+    eqs = [
+        s
+        for s in out.stmts
+        if s.kind == 'equal_segments' and s.origin == 'desugar(circumcircle)'
+    ]
+    assert len(eqs) == 1
+    assert eqs[0].data == {
+        'lhs': [('O_ABC', 'A')],
+        'rhs': [('O_ABC', 'B'), ('O_ABC', 'C'), ('O_ABC', 'E')],
+    }
+
+
+def test_incircle_adds_touch_points_and_equal_radii():
+    circle = stmt('incircle', {'ids': ['A', 'B', 'C']}, {'label': 'incircle'})
+
+    out = desugar(Program([circle]))
+
+    centers = [
+        s
+        for s in out.stmts
+        if s.kind == 'circle_center_radius_through' and s.origin == 'desugar(incircle)'
+    ]
+    assert len(centers) == 1
+    assert centers[0].data == {'center': 'I_ABC', 'through': 'T_AB'}
+    assert centers[0].opts == {'label': 'incircle'}
+
+    point_on = [
+        s
+        for s in out.stmts
+        if s.kind == 'point_on' and s.origin == 'desugar(incircle)'
+    ]
+    assert {s.data['point'] for s in point_on} == {'T_AB', 'T_BC', 'T_CA'}
+    assert {s.data['path'] for s in point_on} == {
+        ('segment', ('A', 'B')),
+        ('segment', ('B', 'C')),
+        ('segment', ('C', 'A')),
+    }
+
+    right_angles = [
+        s
+        for s in out.stmts
+        if s.kind == 'right_angle_at' and s.origin == 'desugar(incircle)'
+    ]
+    assert {(s.data['at'], s.data['rays'][1]) for s in right_angles} == {
+        ('T_AB', ('T_AB', 'A')),
+        ('T_BC', ('T_BC', 'B')),
+        ('T_CA', ('T_CA', 'C')),
+    }
+
+    eqs = [
+        s
+        for s in out.stmts
+        if s.kind == 'equal_segments' and s.origin == 'desugar(incircle)'
+    ]
+    assert len(eqs) == 1
+    assert eqs[0].data == {
+        'lhs': [('I_ABC', 'T_AB')],
+        'rhs': [('I_ABC', 'T_BC'), ('I_ABC', 'T_CA')],
+    }

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -202,3 +202,28 @@ def test_square_residuals_rely_on_desugared_statements():
     for spec in equal_segments:
         vals = spec.func(x)
         assert np.max(np.abs(vals)) < 1e-8
+
+
+def test_translate_registers_circle_helper_points():
+    model = _build_model(
+        """
+        scene "Circle helpers"
+        points A, B, C
+        circle through (A, B, C)
+        """
+    )
+
+    assert "O_ABC" in model.points
+
+
+def test_translate_registers_tangent_touchpoints():
+    model = _build_model(
+        """
+        scene "Circle tangency"
+        points A, B, O
+        segment A-B
+        circle center O tangent (A-B)
+        """
+    )
+
+    assert "T_AB" in model.points


### PR DESCRIPTION
## Summary
- expand desugaring to generate primitive radius, tangency, and equal-radius constraints for circle, circumcircle, and incircle statements
- add deterministic helper-name generation for auxiliary centers and touchpoints
- extend desugar unit tests to cover the new circle expansions

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd6c34a89483239b52f6c3c879611e