### PR TITLE
Lazy load solver in package init

### DIFF
--- a/examples/gir/circle.gir
+++ b/examples/gir/circle.gir
@@ -1,0 +1,25 @@
+# Отрезки $AB$ и $CD$ — диаметры окружности с центром $О$. Найдите периметр треугольника $AOD$, если известно, что $СВ = 13$ см, $AB = 16$ см.
+# --- Геометрическая постановка задачи ---
+scene "Circle"
+layout canonical=euclid scale=1
+points A, B, C, D, O
+
+# Окружность с центром O
+circle center O radius-through A
+equal-segments ( O-A , O-B; O-C, O-D )
+
+# Диаметры: центр лежит на прямых AB и CD
+point O on line A-B
+point O on line C-D
+
+# Треугольник интереса
+triangle A-O-D
+
+# Данные (аннотации длин)
+segment C-B [length=4]
+segment A-B [length=16]
+
+# Цели (для периметра P(AOD) = AO + OD + AD)
+target length A-O
+target length O-D
+target length A-D

--- a/examples/gir/circle_triangle.gir
+++ b/examples/gir/circle_triangle.gir
@@ -1,0 +1,9 @@
+scene "Circle and triangle"
+layout canonical=euclid scale=1
+points A, B, C, O
+circle center O radius-through A
+triangle A-B-C
+segment A-O
+point O on line A-B
+angle at A rays A-O A-C [measure=45]
+rules no_solving=false

--- a/examples/gir/demo.gir
+++ b/examples/gir/demo.gir
@@ -1,0 +1,8 @@
+scene "Isosceles trapezoid with circumcircle"
+layout canonical=generic_auto scale=1
+trapezoid A-B-C-D [bases=A-D isosceles=true]
+circle through (A, B, C, D)
+points E
+angle at E rays E-A E-B
+target angle at A rays A-B A-D
+rules no_solving=true

--- a/geoscript_ir/__init__.py
+++ b/geoscript_ir/__init__.py
@@ -1,3 +1,16 @@
+"""Public package surface for :mod:`geoscript_ir`.
+
+The CLI entry point only needs the parsing and validation helpers.  Importing the
+numeric solver eagerly pulls in heavy optional dependencies (``numpy`` and
+``scipy``).  Those packages are required when the solver is used but should not
+be mandatory just to run the light-weight tooling exposed by
+``python -m geoscript_ir``.  To keep the import-time footprint small we lazily
+expose the solver symbols via ``__getattr__`` so that the modules are loaded
+only when they are actually needed.
+"""
+
+from typing import TYPE_CHECKING
+
 from .parser import parse_program
 from .validate import validate, ValidationError
 from .desugar import desugar
@@ -5,16 +18,42 @@ from .consistency import check_consistency
 from .printer import print_program
 from .ast import Program, Stmt, Span
 from .reference import BNF, LLM_PROMPT, get_llm_prompt
-from .solver import (
-    translate,
-    solve,
-    SolveOptions,
-    Model,
-    Solution,
-)
+
+if TYPE_CHECKING:  # pragma: no cover - import only used for type checkers
+    from .solver import Model, Solution, SolveOptions, solve, translate
 
 __all__ = [
-    'parse_program', 'validate', 'ValidationError', 'desugar', 'check_consistency', 'print_program',
-    'translate', 'solve', 'SolveOptions', 'Model', 'Solution',
-    'Program', 'Stmt', 'Span', 'BNF', 'LLM_PROMPT', 'get_llm_prompt'
+    "parse_program",
+    "validate",
+    "ValidationError",
+    "desugar",
+    "check_consistency",
+    "print_program",
+    "translate",
+    "solve",
+    "SolveOptions",
+    "Model",
+    "Solution",
+    "Program",
+    "Stmt",
+    "Span",
+    "BNF",
+    "LLM_PROMPT",
+    "get_llm_prompt",
 ]
+
+_LAZY_SOLVER_ATTRS = {"translate", "solve", "SolveOptions", "Model", "Solution"}
+
+
+def __getattr__(name: str):
+    if name in _LAZY_SOLVER_ATTRS:
+        from . import solver as _solver
+
+        value = getattr(_solver, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module 'geoscript_ir' has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(__all__)


### PR DESCRIPTION
## Summary
- lazily expose solver symbols from geoscript_ir.__init__ to avoid requiring optional numeric dependencies for the CLI
- add dedicated examples/gir/ fixtures, including a new circle_triangle.gir scenario

## Testing
- python3 -m geoscript_ir examples/gir/circle.gir
- python3 -m geoscript_ir examples/gir/circle_triangle.gir
- python3 -m geoscript_ir examples/gir/demo.gir


------
https://chatgpt.com/codex/tasks/task_e_68cda3490e7c8323b9f8b86396574e06