### PR TITLE
Add explicit angle and perpendicular bisector paths

### DIFF
--- a/docs/bnf.txt
+++ b/docs/bnf.txt
@@ -26,7 +26,8 @@ Obj       := 'segment' Pair Opts?
            | 'incircle'    'of' IdChain Opts?
            | 'perpendicular' 'at' ID 'to' Pair Opts?
            | 'parallel' 'through' ID 'to' Pair Opts?
-           | 'bisector' 'at' ID Opts?
+           | 'angle-bisector' 'at' ID 'rays' Pair Pair Opts?
+           | 'perpendicular-bisector' 'of' Pair Opts?
            | 'median'  'from' ID 'to' Pair Opts?
            | 'altitude' 'from' ID 'to' Pair Opts?
            | 'angle' 'at' ID 'rays' Pair Pair Opts?
@@ -51,6 +52,8 @@ Path      := 'line'    Pair
            | 'ray'     Pair
            | 'segment' Pair
            | 'circle' 'center' ID
+           | 'angle-bisector' 'at' ID 'rays' Pair Pair
+           | 'perpendicular-bisector' 'of' Pair
 
 EdgeList  := Pair { ',' Pair }
 IdList    := ID { ',' ID }

--- a/geoscript_ir/parser.py
+++ b/geoscript_ir/parser.py
@@ -141,22 +141,41 @@ def parse_opt_value(cur: Cursor):
 
 
 def parse_path(cur: Cursor):
-    kind_tok = cur.expect('ID')
-    kind = kind_tok[1].lower()
-    if kind == 'line':
+    kw = cur.peek_keyword()
+    t = cur.peek()
+    if not kw or not t:
+        raise SyntaxError(f'[line {t[2] if t else 0}, col {t[3] if t else 0}] expected path keyword')
+    if kw == 'line':
+        cur.consume_keyword('line')
         e, _ = parse_pair(cur)
         return 'line', e
-    if kind == 'ray':
+    if kw == 'ray':
+        cur.consume_keyword('ray')
         r, _ = parse_pair(cur)
         return 'ray', r
-    if kind == 'segment':
+    if kw == 'segment':
+        cur.consume_keyword('segment')
         e, _ = parse_pair(cur)
         return 'segment', e
-    if kind == 'circle':
+    if kw == 'circle':
+        cur.consume_keyword('circle')
         cur.consume_keyword('center')
         center, _ = parse_id(cur)
         return 'circle', center
-    raise SyntaxError(f'[line {kind_tok[2]}, col {kind_tok[3]}] invalid path kind {kind_tok[1]}')
+    if kw == 'angle-bisector':
+        cur.consume_keyword('angle-bisector')
+        cur.consume_keyword('at')
+        at, _ = parse_id(cur)
+        cur.consume_keyword('rays')
+        r1, _ = parse_pair(cur)
+        r2, _ = parse_pair(cur)
+        return 'angle-bisector', {'at': at, 'rays': (r1, r2)}
+    if kw == 'perpendicular-bisector':
+        cur.consume_keyword('perpendicular-bisector')
+        cur.consume_keyword('of')
+        of, _ = parse_pair(cur)
+        return 'perpendicular-bisector', {'of': of}
+    raise SyntaxError(f'[line {t[2]}, col {t[3]}] invalid path kind {t[1]!r}')
 
 def parse_opts(cur: Cursor) -> Dict[str, Any]:
     opts: Dict[str, Any] = {}
@@ -370,12 +389,21 @@ def parse_stmt(tokens: List[Tuple[str, str, int, int]]):
         to, _ = parse_pair(cur)
         opts = parse_opts(cur)
         stmt = Stmt('parallel_through', sp, {'through': through, 'to': to}, opts)
-    elif kw == 'bisector':
-        cur.consume_keyword('bisector')
+    elif kw == 'angle-bisector':
+        cur.consume_keyword('angle-bisector')
         cur.consume_keyword('at')
         at, sp = parse_id(cur)
+        cur.consume_keyword('rays')
+        r1, _ = parse_pair(cur)
+        r2, _ = parse_pair(cur)
         opts = parse_opts(cur)
-        stmt = Stmt('bisector_at', sp, {'at': at}, opts)
+        stmt = Stmt('angle_bisector_at', sp, {'at': at, 'rays': (r1, r2)}, opts)
+    elif kw == 'perpendicular-bisector':
+        cur.consume_keyword('perpendicular-bisector')
+        cur.consume_keyword('of')
+        of, sp = parse_pair(cur)
+        opts = parse_opts(cur)
+        stmt = Stmt('perpendicular_bisector_of', sp, {'of': of}, opts)
     elif kw == 'median':
         cur.consume_keyword('median')
         cur.consume_keyword('from')

--- a/geoscript_ir/reference.py
+++ b/geoscript_ir/reference.py
@@ -32,7 +32,8 @@ BNF = dedent(
                | 'incircle'    'of' IdChain Opts?
                | 'perpendicular' 'at' ID 'to' Pair Opts?
                | 'parallel' 'through' ID 'to' Pair Opts?
-               | 'bisector' 'at' ID Opts?
+               | 'angle-bisector' 'at' ID 'rays' Pair Pair Opts?
+               | 'perpendicular-bisector' 'of' Pair Opts?
                | 'median'  'from' ID 'to' Pair Opts?
                | 'altitude' 'from' ID 'to' Pair Opts?
                | 'angle' 'at' ID 'rays' Pair Pair Opts?
@@ -57,6 +58,8 @@ BNF = dedent(
                | 'ray'     Pair
                | 'segment' Pair
                | 'circle' 'center' ID
+               | 'angle-bisector' 'at' ID 'rays' Pair Pair
+               | 'perpendicular-bisector' 'of' Pair
 
     EdgeList  := Pair { ',' Pair }
     IdList    := ID { ',' ID }
@@ -118,7 +121,8 @@ _PROMPT_CORE = dedent(
     - incircle of A-B-C
     - perpendicular at A to B-C
     - parallel through A to B-C
-    - bisector at A
+    - angle-bisector at A rays A-B A-C
+    - perpendicular-bisector of A-B
     - median from A to B-C
     - altitude from A to B-C
     - angle at A rays A-B A-C [degrees=60]
@@ -138,8 +142,11 @@ _PROMPT_CORE = dedent(
     Placements (point locations and intersections):
     - point P on line A-B [mark=midpoint]
     - point Q on ray A-B / segment A-B / circle center O [choose="near A"]
+    - point R on angle-bisector at A rays A-B A-C [external=true]
     - intersect (line A-B) with (circle center O) at X[, Y] [type=external]
-      Paths inside parentheses are one of: `line A-B`, `ray A-B`, `segment A-B`, `circle center O`.
+      Paths inside parentheses are one of: `line A-B`, `ray A-B`, `segment A-B`,
+      `circle center O`, `angle-bisector at A rays A-B A-C`,
+      `perpendicular-bisector of A-B`.
 
     Annotations:
     - label point A [text="A"]

--- a/geoscript_ir/solver.py
+++ b/geoscript_ir/solver.py
@@ -377,6 +377,45 @@ def _build_point_on(stmt: Stmt, index: Dict[PointName, int]) -> List[ResidualSpe
         key = f"point_on_circle({point},{center})"
         return [ResidualSpec(key=key, func=func, size=1, kind="point_on_circle", source=stmt)]
 
+    if path_kind == "perpendicular-bisector" and isinstance(payload, dict):
+        edge = payload.get("of")
+        if not isinstance(edge, (list, tuple)) or len(edge) != 2:
+            raise ValueError("perpendicular-bisector path requires an edge")
+        a, b = edge[0], edge[1]
+
+        def func(x: np.ndarray) -> np.ndarray:
+            p = _vec(x, index, point)
+            va = _vec(x, index, a)
+            vb = _vec(x, index, b)
+            return np.array([_norm_sq(p - va) - _norm_sq(p - vb)], dtype=float)
+
+        key = f"point_on_perpendicular_bisector({point},{_format_edge((a, b))})"
+        return [ResidualSpec(key=key, func=func, size=1, kind="point_on_perpendicular_bisector", source=stmt)]
+
+    if path_kind == "angle-bisector" and isinstance(payload, dict):
+        at = payload.get("at")
+        rays = payload.get("rays")
+        if not isinstance(at, str) or not isinstance(rays, (list, tuple)) or len(rays) != 2:
+            raise ValueError("angle-bisector path requires vertex and two rays")
+        ray1 = _as_edge(rays[0])
+        ray2 = _as_edge(rays[1])
+        arm1 = ray1[1]
+        arm2 = ray2[1]
+
+        def func(x: np.ndarray) -> np.ndarray:
+            p = _vec(x, index, point)
+            v = _vec(x, index, at)
+            a = _vec(x, index, arm1)
+            b = _vec(x, index, arm2)
+            lhs = _norm_sq(p - a) * _norm_sq(v - b)
+            rhs = _norm_sq(p - b) * _norm_sq(v - a)
+            return np.array([lhs - rhs], dtype=float)
+
+        key = (
+            f"point_on_angle_bisector({point},{at};{_format_edge(ray1)},{_format_edge(ray2)})"
+        )
+        return [ResidualSpec(key=key, func=func, size=1, kind="point_on_angle_bisector", source=stmt)]
+
     raise ValueError(f"Unsupported path kind for point_on: {path_kind}")
 
 
@@ -551,6 +590,22 @@ def translate(program: Program) -> Model:
             return
         if kind == "circle" and isinstance(payload, str):
             _register_point(order, seen, payload)
+            return
+        if kind == "angle-bisector" and isinstance(payload, dict):
+            at = payload.get("at")
+            if isinstance(at, str):
+                _register_point(order, seen, at)
+            rays = payload.get("rays")
+            if isinstance(rays, (list, tuple)):
+                for ray in rays:
+                    if isinstance(ray, (list, tuple)):
+                        handle_edge(ray)
+            return
+        if kind == "perpendicular-bisector" and isinstance(payload, dict):
+            of = payload.get("of")
+            if isinstance(of, (list, tuple)):
+                handle_edge(of)
+            return
 
     # scan program
     for stmt in program.stmts:
@@ -619,6 +674,8 @@ def translate(program: Program) -> Model:
         if "rhs" in data:
             for edge in data["rhs"]:
                 handle_edge(edge)
+        if "of" in data and isinstance(data["of"], (list, tuple)):
+            handle_edge(data["of"])
         if "rays" in data:
             for ray in data["rays"]:
                 handle_edge(ray)

--- a/tests/integrational/gir/triangle_isosceles.gir
+++ b/tests/integrational/gir/triangle_isosceles.gir
@@ -10,6 +10,6 @@ angle at C rays C-A C-B [label="50^\\circ"]
 segment B-C
 point D on segment B-C
 line A-D
-bisector at A
+angle-bisector at A rays A-B A-C
 # Цель: угол ADC
 target angle at D rays D-A D-C [label="?ADC"]

--- a/tests/test_bnf.py
+++ b/tests/test_bnf.py
@@ -115,7 +115,18 @@ def test_targets(text, kind, data, opts):
             {'through': 'A', 'to': ('B', 'C')},
             {'mark': True},
         ),
-        ('bisector at A', 'bisector_at', {'at': 'A'}, {}),
+        (
+            'angle-bisector at A rays A-B A-C',
+            'angle_bisector_at',
+            {'at': 'A', 'rays': (('A', 'B'), ('A', 'C'))},
+            {},
+        ),
+        (
+            'perpendicular-bisector of A-B',
+            'perpendicular_bisector_of',
+            {'of': ('A', 'B')},
+            {},
+        ),
         (
             'median from A to B-C',
             'median_from_to',
@@ -194,6 +205,20 @@ def test_placements():
     assert pt_on_line.data == {'point': 'Y', 'path': ('line', ('A', 'B'))}
     assert pt_on_line.opts == {'mark': 'midpoint'}
 
+    pt_on_angle = parse_single('point R on angle-bisector at A rays A-B A-C')
+    assert pt_on_angle.kind == 'point_on'
+    assert pt_on_angle.data == {
+        'point': 'R',
+        'path': ('angle-bisector', {'at': 'A', 'rays': (('A', 'B'), ('A', 'C'))}),
+    }
+
+    pt_on_perp = parse_single('point S on perpendicular-bisector of B-C')
+    assert pt_on_perp.kind == 'point_on'
+    assert pt_on_perp.data == {
+        'point': 'S',
+        'path': ('perpendicular-bisector', {'of': ('B', 'C')}),
+    }
+
     inter = parse_single('intersect (line A-B) with (circle center O) at P, Q [type=external]')
     assert inter.kind == 'intersect'
     assert inter.data == {
@@ -203,6 +228,15 @@ def test_placements():
         'at2': 'Q',
     }
     assert inter.opts == {'type': 'external'}
+
+    inter2 = parse_single('intersect (angle-bisector at A rays A-B A-C) with (perpendicular-bisector of B-C) at T')
+    assert inter2.kind == 'intersect'
+    assert inter2.data == {
+        'path1': ('angle-bisector', {'at': 'A', 'rays': (('A', 'B'), ('A', 'C'))}),
+        'path2': ('perpendicular-bisector', {'of': ('B', 'C')}),
+        'at': 'T',
+        'at2': None,
+    }
 
 
 def test_rules():


### PR DESCRIPTION
## Summary
- split the generic bisector construct into explicit angle-bisector and perpendicular-bisector productions and expose them as paths
- extend the parser, printer, and solver so angle/perpendicular bisectors can be parsed, printed, and used in point-on/intersection constraints
- refresh documentation, reference text, and tests (including GIR fixtures) to exercise the new syntax

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68cdb7ba2c18832389c25b0b3f50c97f