### PR TITLE
Add coordinate normalization utility

### DIFF
--- a/geoscript_ir/__init__.py
+++ b/geoscript_ir/__init__.py
@@ -11,10 +11,11 @@ from .solver import (
     SolveOptions,
     Model,
     Solution,
+    normalize_point_coords,
 )
 
 __all__ = [
     'parse_program', 'validate', 'ValidationError', 'desugar', 'check_consistency', 'print_program',
-    'translate', 'solve', 'SolveOptions', 'Model', 'Solution',
+    'translate', 'solve', 'SolveOptions', 'Model', 'Solution', 'normalize_point_coords',
     'Program', 'Stmt', 'Span', 'BNF', 'LLM_PROMPT', 'get_llm_prompt'
 ]


### PR DESCRIPTION
## Summary
- add a utility to normalize solved point coordinates and expose it via the solver module
- provide a convenience method on `Solution` to access normalized coordinates
- cover normalization behaviour with new solver tests

## Testing
- `pytest tests/test_solver.py`


------
https://chatgpt.com/codex/tasks/task_e_68cdd67def848323be9ae7955d3cda12