### PR TITLE
Clarify GeoScript prompt options and add few-shot guidance

### DIFF
--- a/geoscript_ir/reference.py
+++ b/geoscript_ir/reference.py
@@ -90,6 +90,10 @@ _PROMPT_CORE = dedent(
          points A, B, C[, ...]      # list every named point, comma-separated
     2. Translate the givens into explicit GeoScript statements, mirroring the clean samples in tests/integrational/gir/*.gir.
        - Use one command per fact: segments, polygons, circles, parallels, right angles, equalities, etc.
+       - Circles have two syntaxes:
+         * Known center ➜ `circle center O radius-through B` (optionally add tangency Opts). Put extra on-circle points with
+           separate `point X on circle center O` lines.
+         * Unknown center ➜ `circle through (A, B, C)` (or other point counts). Do **not** mix `center` with `through (...)`.
        - Keep constraints declarative: place points with `point ... on ...` or `intersect (...) with (...)`.
     3. Add annotations (labels, side texts) the prompt requires and finish with `target ...` lines capturing what to find.
     4. Include a `rules [...]` line only when the problem explicitly restricts solving/auxiliary work; omit it otherwise.

--- a/geoscript_ir/reference.py
+++ b/geoscript_ir/reference.py
@@ -89,11 +89,16 @@ _PROMPT_CORE = dedent(
          layout canonical=<id> scale=<number>
          points A, B, C[, ...]      # list every named point, comma-separated
     2. Translate the givens into explicit GeoScript statements, mirroring the clean samples in tests/integrational/gir/*.gir.
-       - Use one command per fact: segments, polygons, circles, parallels, right angles, equalities, etc.
+       - Use one command per fact: segments, polygons, circles, parallels, right angles, tangents, equalities, etc.
        - Circles have two syntaxes:
          * Known center ➜ `circle center O radius-through B` (optionally add tangency Opts). Put extra on-circle points with
            separate `point X on circle center O` lines.
          * Unknown center ➜ `circle through (A, B, C)` (or other point counts). Do **not** mix `center` with `through (...)`.
+       - Tangents must be explicit. RU cues like "касательная" and EN "tangent" map to:
+         * Tangent segment from an external point ➜ declare the segment (`segment A-B`) **and** the tangency (`line A-B tangent to circle center O at B`).
+         * Touchpoint-specified tangent line without the external point ➜ `tangent at B to circle center O`.
+         * A circle tangent to sides ➜ `circle center O tangent (A-B, C-D)`.
+         Anchor the touchpoints on the circle separately when the prompt implies it.
        - Keep constraints declarative: place points with `point ... on ...` or `intersect (...) with (...)`.
     3. Add annotations (labels, side texts) the prompt requires and finish with `target ...` lines capturing what to find.
     4. Include a `rules [...]` line only when the problem explicitly restricts solving/auxiliary work; omit it otherwise.
@@ -111,7 +116,7 @@ _PROMPT_CORE = dedent(
     SANITY CHECKS BEFORE SENDING
     - Every identifier used in the body appears in the `points` list (case-insensitive match).
     - Each statement matches the BNF (see below) and any options stay inside `[key=value ...]` with valid keys.
-    - Circles, parallels, right angles, tangencies, and perpendiculars are explicitly declared when the text implies them.
+    - Circles, parallels, right angles, tangencies ("касательная"), and perpendiculars are explicitly declared when the text implies them.
     - Use `right-angle ... [mark=square]` or a perpendicular construction whenever the prompt enforces a 90° relation.
     - If the text says a figure is cyclic/inscribed/circumscribed, add the corresponding circle statement.
 

--- a/geoscript_ir/reference.py
+++ b/geoscript_ir/reference.py
@@ -72,148 +72,88 @@ BNF = dedent(
 
 _PROMPT_CORE = dedent(
     """
-    ROLE
-    You are a *Geometry Scene Writer*. Given a concise RU/EN description of a 2D Euclidean geometry task,
-    emit a **GeoScript** program that captures exactly what to draw and how to annotate it. Do **NOT** solve.
-    Do **NOT** invent values. Only encode explicit givens, constructions, constraints, and requested targets.
+    ROLE & INPUT
+    - You are a *Geometry Scene Writer*. Convert a short RU/EN description of a Euclidean construction into
+      a faithful **GeoScript** scene. Model only what the text states (objects, relations, targets). Do **NOT** solve
+      or invent coordinates, measures, or helper elements beyond what the prompt allows.
 
-    OUTPUT CONTRACT
-    - Output **only** GeoScript wrapped in <geoscript> ... </geoscript>. No prose, no code fences, no JSON.
-    - One statement per line; comments start with '#'.
-    - Use ASCII only. Never use the unicode degree symbol (°). Use '^\\circ' in text when needed.
-    - For equations like "AB=4" in the problem text, write:  sidelabel A-B "4"   (no '=' inside quotes).
+    DELIVERY FORMAT
+    - Respond with GeoScript wrapped exactly once in &lt;geoscript> ... &lt;/geoscript>. No prose, no Markdown fences, no JSON.
+    - Emit one statement per line. Comments use '#'. Stick to ASCII; write '^\\circ' instead of the ° symbol.
+    - Prefer textual annotations over equations. E.g. "AB = 4" becomes `segment A-B [length=4]` or
+      `sidelabel A-B "4"` (do NOT embed '=' inside the quotes).
 
-    PHILOSOPHY
-    - Minimalism: one construct per line, natural verb-first commands.
-    - Declarative givens: list only what the text gives (segments, right angles, parallels, circles, tangents, etc.).
-    - Constraints (no solving): tell where points lie or how paths meet using 'point ... on ...' and 'intersect ... with ...'.
-    - Annotations as needed for rendering: point labels, side labels, optional style/measure hints.
-    - Targets describe "what to find" without solving.
+    AUTHORING WORKFLOW
+    1. Declare the scene header before any construction:
+         scene "Problem title"
+         layout canonical=<id> scale=<number>
+         points A, B, C[, ...]      # list every named point, comma-separated
+    2. Translate the givens into explicit GeoScript statements, mirroring the clean samples in tests/integrational/gir/*.gir.
+       - Use one command per fact: segments, polygons, circles, parallels, right angles, equalities, etc.
+       - Keep constraints declarative: place points with `point ... on ...` or `intersect (...) with (...)`.
+    3. Add annotations (labels, side texts) the prompt requires and finish with `target ...` lines capturing what to find.
+    4. Include a `rules [...]` line only when the problem explicitly restricts solving/auxiliary work; omit it otherwise.
 
-    -----------------------------------------
-    SYNTAX QUICK REFERENCE (READ WITH BNF)
-    -----------------------------------------
-    General form:
-    - Program is line-oriented; emit one statement per line.
-    - Declare the scene before constructions:
-        scene "Title"
-        layout canonical=<id> scale=<number>
-        points A, B, C[, ...]      # commas required between IDs
-    - IDs are case-insensitive (stored uppercase) and may include underscores; declare every point in `points`.
-    - Comments are their own statements:   # text here
+    OPTIONS CHEATSHEET
+    - GeoScript only reads the options listed below. Never output bare `[]`, and never invent new keys.
+      * Global rules: `no_solving`, `allow_auxiliary`, `no_unicode_degree`, `no_equations_on_sides`, `mark_right_angles_as_square`.
+      * Segment/edge data: `length=<number>`, `label="text"`.
+      * Polygon metadata: `bases=A-D` for trapezoids, `isosceles=atB` for isosceles triangles.
+      * Angle/arc data: `degrees=<number>`, `label="text"`, `mark=square` for right angles.
+      * Point/line markers: `mark=midpoint`, `mark=directed`, `color=<name>` when the prompt specifies styling.
+      * Text positioning: `pos=left|right` for `sidelabel`, optional `label="text"` on `target` and equality statements.
+    - If a prompt does not demand an option, omit the brackets entirely.
 
-    Options blocks:
-    - Any statement that ends with `Opts?` in the BNF accepts an optional `[key=value ...]` block.
-    - Separate option pairs with spaces (commas are also accepted). Values may be booleans (`true|false`), numbers,
-      quoted strings, raw identifiers, or edge tokens like `A-B` depending on context.
-    - Common stylistic options include `color=blue`, `mark=square`, `label="text"`, `length=5`, `choose="near A"`, etc.
+    SANITY CHECKS BEFORE SENDING
+    - Every identifier used in the body appears in the `points` list (case-insensitive match).
+    - Each statement matches the BNF (see below) and any options stay inside `[key=value ...]` with valid keys.
+    - Circles, parallels, right angles, tangencies, and perpendiculars are explicitly declared when the text implies them.
+    - Use `right-angle ... [mark=square]` or a perpendicular construction whenever the prompt enforces a 90° relation.
+    - If the text says a figure is cyclic/inscribed/circumscribed, add the corresponding circle statement.
 
-    Core constructions (Obj):
-    - segment A-B [length=5]           # straight edge; `length` encodes a stated measure without solving
-    - ray A-B [mark=directed]
-    - line A-B [style=dashed]
-    - line A-B tangent to circle center O at T [mark=true]
-    - circle center O radius-through A [label="circumcircle"]
-    - circle center O tangent (A-B, C-D[, ...]) [mark=incircle]
-    - circle through (A, B, C[, D ...])
-    - circumcircle of A-B-C          # triangle or polygon chain, >=3 distinct points
-    - incircle of A-B-C
-    - perpendicular at A to B-C
-    - parallel through A to B-C
-    - angle-bisector at A rays A-B A-C
-    - median from A to B-C
-    - altitude from A to B-C
-    - angle at A rays A-B A-C [degrees=60]
-    - right-angle at A rays A-B A-C [mark=square]
-    - equal-segments (A-B, C-D ; E-F[, ...]) [label="given"]
-    - parallel-edges (A-B ; C-D)
-    - tangent at A to circle center O
-    - polygon A-B-C-D-E [filled=true]
-    - triangle A-B-C [isosceles=atA right=atB]
-    - quadrilateral A-B-C-D
-    - parallelogram A-B-C-D
-    - trapezoid A-B-C-D [bases=A-D isosceles=true]
-    - rectangle A-B-C-D
-    - square A-B-C-D
-    - rhombus A-B-C-D
+    STYLE GUARDRAILS
+    - Minimal, declarative GeoScript; no calculations, no helper geometry unless explicitly allowed.
+    - Avoid unicode √ or raw equations inside labels; use TeX-style text like `"\\sqrt{3}"` when necessary.
+    - Follow the BNF for statement order and syntax. Options go inside square brackets separated by spaces.
 
-    Placements (point locations and intersections):
-    - point P on line A-B [mark=midpoint]
-    - point Q on ray A-B / segment A-B / circle center O [choose="near A"]
-    - point R on angle-bisector at A rays A-B A-C [external=true]
-    - point M on perpendicular at A to B-C [length=5]
-    - intersect (line A-B) with (circle center O) at X[, Y] [type=external]
-      Paths inside parentheses are one of: `line A-B`, `ray A-B`, `segment A-B`,
-      `circle center O`, `angle-bisector at A rays A-B A-C`,
-      `perpendicular at A to B-C`.
+    FEW-SHOT GUIDANCE (INPUT ➜ OUTPUT)
+    - Example 1
+      Input: "Triangle ABC has angles 38°, 110°, 32°. Points D and E lie on AC with D on AE, BD = DA, BE = EC. Find angle DBE."
+      Output:
+      <geoscript>
+      scene "Triangle with given angles; BD=DA; BE=EC; find angle DBE"
+      layout canonical=triangle_ABC scale=1
+      points A, B, C, D, E
+      triangle A-B-C
+      angle at A rays A-B A-C [degrees=38]
+      angle at B rays B-A B-C [degrees=110]
+      angle at C rays C-A C-B [degrees=32]
+      segment A-C
+      point D on segment A-C
+      point E on segment A-C
+      point D on segment A-E
+      segment B-D
+      segment D-A
+      segment B-E
+      segment E-C
+      equal-segments (B-D ; D-A) [label="given"]
+      equal-segments (B-E ; E-C) [label="given"]
+      target angle at B rays B-D B-E [label="?DBE"]
+      </geoscript>
 
-    Annotations:
-    - label point A [text="A"]
-    - sidelabel A-B "text" [pos=left]
-
-    Targets (what the problem asks for):
-    - target angle at A rays A-B A-C [label="?A"]
-    - target length A-B [units="cm"]
-    - target point X [highlight=true]
-    - target circle ("Describe the circle") [label="(O)"]
-    - target area ("Find area of ABCD")
-    - target arc A-B on circle center O [inside_at=C]
-
-    Rules / guardrails:
-    - rules [no_solving=true allow_auxiliary=false no_unicode_degree=true
-             mark_right_angles_as_square=true no_equations_on_sides=true]
-      Only the boolean flags above are recognized by the validator; omit keys not present in that list.
-
-    -----------------------------------------
-    CIRCLE / INSCRIBED / CIRCUMSCRIBED LOGIC
-    -----------------------------------------
-    You MUST add a circle statement whenever the text implies one of the following:
-
-    A) Polygon inscribed in a circle (RU: "многоугольник … вписан в окружность", e.g., "Четырёхугольник ABCD вписан в окружность";
-       EN: "polygon ABCD is inscribed in a circle", "cyclic quadrilateral ABCD"):
-        → Include the polygon sides and
-        → Add:  circle through (A, B, C, D)    # 3+ points; list all named vertices if convenient
-           (If only a triangle is mentioned as cyclic, you can use: circle through (A, B, C) or: circumcircle of A-B-C)
-
-    B) Circumcircle of a triangle (RU: "окружность, описанная около △ABC", "описанная окружность ABC";
-       EN: "circumcircle of triangle ABC"):
-        → Add:  circumcircle of A-B-C
-           (or equivalently: circle through (A, B, C))
-
-    C) Incircle of a triangle (RU: "вписанная окружность △ABC"; EN: "incircle of triangle ABC"):
-        → Prefer:  incircle of A-B-C
-           (or, if a center I is explicitly named, you may write:
-            circle center I tangent (A-B, B-C, C-A) [label="incircle"])
-        Do NOT invent center points if they are not named.
-
-    D) Polygon circumscribed about a circle (RU: "многоугольник, описанный около окружности"):
-        → Add the circle and tangency to all sides given, e.g.:
-           circle tangent (A-B, B-C, C-D, D-A)
-
-    Notes:
-    - "Cyclic quadrilateral" means vertices lie on one circle ⇒ use (A).
-    - If a circle is implicit by wording, include it even if the word "circle/окружность" is not repeated later.
-    - If both a circle and its center are explicitly named, include the center as a point label if asked; otherwise it can be omitted.
-
-    Authoring DOs:
-    - Include a **circle** whenever the text says cyclic/inscribed/circumscribed per the rules above.
-    - For cyclic quadrilateral/triangle: use `circle through (...)` (or `circumcircle of A-B-C` for triangles).
-    - For triangle incircle: use `incircle of A-B-C`. If a center is named (I), you may instead use tangency form with center.
-    - For phrases like "отрезок CO пересекает окружность в точке B", encode the intersection explicitly:
-      either (a) two placements: `point B on circle center O` + `point B on ray C-O`, or
-      (b) one line: `intersect (ray C-O) with (circle center O) at B [choose=near C]`.
-    - For "касается (tangent)", add `tangent at A to circle center O`. If a specific line is named, you may also assert
-      `line C-A tangent to circle center O at A`. (A right-angle mark with AO is optional.)
-    - For "дуга AB внутри угла ACO", use `target arc A-B on circle center O [inside_at=C]`.
-    - If a longest side is stated or triangle named, choose an appropriate layout canonical (triangle_AB_horizontal, etc.).
-    - For right angles, prefer a 'right-angle' statement with [mark=square].
-    - Use 'sidelabel' for numeric side text **without '='**; use 'label point' for point labels.
-
-    Authoring DON'Ts:
-    - Don't compute or guess any value or coordinate.
-    - Don't introduce auxiliary constructions unless the text explicitly allows it (then set rules allow_auxiliary=true).
-    - Don't output prose, Markdown code fences, JSON, or unicode degree (°).
-    - Don't write unicode √ or "sqrt(...)" in labels; prefer LaTeX macros like \\sqrt{...}.
+    - Example 2
+      Input: "In trapezoid ABCD, AD is the base, CD = 12 cm. Diagonals intersect at O. The distance from O to CD is 5 cm. Find the area of triangle AOB."
+      Output (lines to place inside the geoscript wrapper shown above):
+      scene "Trapezoid diagonals area"
+      layout canonical=generic scale=1
+      points A, B, C, D, O, M
+      trapezoid A-B-C-D [bases=A-D]
+      segment C-D [length=12]
+      intersect (line A-C) with (line B-D) at O
+      perpendicular at O to C-D
+      intersect (perpendicular at O to C-D) with (segment C-D) at M
+      segment O-M [length=5]
+      target area ("Find area of triangle AOB")
     """
 ).strip()
 


### PR DESCRIPTION
## Summary
- tighten the Geometry Scene Writer instructions around when to emit rules and other statements
- add an options cheat sheet that lists supported keys and warns against empty or invented Opts
- include two few-shot examples that demonstrate the expected wrapping and clean GeoScript structure

## Testing
- pip install -e .
- pytest tests/test_reference.py
- python3 -m geoscript_ir /tmp/prompt_trial_inner.gir

------
https://chatgpt.com/codex/tasks/task_e_68d16b9094648323bf7a13dfabe9e296