### PR TITLE
Add option to print only original statements

### DIFF
--- a/geoscript_ir/printer.py
+++ b/geoscript_ir/printer.py
@@ -31,9 +31,11 @@ def path_str(path: Tuple[str, object]) -> str:
         return f'median from {frm}'
     return f'# [unknown path {kind}]'
 
-def print_program(prog: Program) -> str:
+def print_program(prog: Program, *, original_only: bool = False) -> str:
     lines = []
     for s in prog.stmts:
+        if original_only and s.origin != 'source':
+            continue
         o = ''
         if s.opts:
             parts = []

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -17,3 +17,16 @@ def test_segment_length_prints_symbolic_value():
     prog = Program([stmt])
 
     assert print_program(prog) == 'segment A-B [length=sqrt(19)]\n'
+
+
+def test_original_only_skips_generated_statements():
+    original = Stmt('segment', Span(1, 1), {'edge': ('A', 'B')})
+    generated = Stmt(
+        'segment',
+        Span(2, 1),
+        {'edge': ('B', 'C')},
+        origin='desugar(triangle)',
+    )
+    prog = Program([original, generated])
+
+    assert print_program(prog, original_only=True) == 'segment A-B\n'


### PR DESCRIPTION
## Summary
- add an `original_only` flag to `print_program` so callers can omit desugared statements
- cover the new behavior with a dedicated printer test

## Testing
- pip install -e .
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d3eb4c12188323a37ca1e95b620876