### PR TITLE
Add diameter statement syntax and desugar support

### DIFF
--- a/docs/bnf.txt
+++ b/docs/bnf.txt
@@ -34,6 +34,7 @@ Obj       := 'segment' Pair Opts?
            | 'equal-segments' '(' EdgeList ';' EdgeList ')' Opts?
            | 'parallel-edges' '(' Pair ';' Pair ')' Opts?
            | 'tangent' 'at' ID 'to' 'circle' 'center' ID Opts?
+           | 'diameter' Pair 'to' 'circle' 'center' ID Opts?
            | 'line' ID '-' ID 'tangent' 'to' 'circle' 'center' ID 'at' ID Opts?
            | 'polygon' IdChain Opts?
            | 'triangle' ID '-' ID '-' ID Opts?

--- a/geoscript_ir/desugar.py
+++ b/geoscript_ir/desugar.py
@@ -538,6 +538,22 @@ def desugar_variants(prog: Program) -> List[Program]:
                             source_keys,
                             generated=True,
                         )
+        elif s.kind == 'diameter':
+            center = s.data['center']
+            segment = s.data['edge']
+            for state in states:
+                _append(
+                    state,
+                    Stmt(
+                        'point_on',
+                        s.span,
+                        {'point': center, 'path': ('segment', segment)},
+                        {},
+                        origin='desugar(diameter)'
+                    ),
+                    source_keys,
+                    generated=True,
+                )
 
     return [state.program for state in states]
 

--- a/geoscript_ir/parser.py
+++ b/geoscript_ir/parser.py
@@ -522,6 +522,15 @@ def parse_stmt(tokens: List[Tuple[str, str, int, int]]):
         center, _ = parse_id(cur)
         opts = parse_opts(cur)
         stmt = Stmt('tangent_at', sp, {'at': at, 'center': center}, opts)
+    elif kw == 'diameter':
+        cur.consume_keyword('diameter')
+        edge, sp = parse_pair(cur)
+        cur.consume_keyword('to')
+        cur.consume_keyword('circle')
+        cur.consume_keyword('center')
+        center, _ = parse_id(cur)
+        opts = parse_opts(cur)
+        stmt = Stmt('diameter', sp, {'edge': edge, 'center': center}, opts)
     elif kw == 'polygon':
         cur.consume_keyword('polygon')
         ids, sp = parse_idchain(cur)

--- a/geoscript_ir/printer.py
+++ b/geoscript_ir/printer.py
@@ -97,6 +97,11 @@ def print_program(prog: Program) -> str:
             lines.append(f'equal-segments ({lhs} ; {rhs})')
         elif s.kind == 'tangent_at':
             lines.append(f'tangent at {s.data["at"]} to circle center {s.data["center"]}{o}'); continue
+        elif s.kind == 'diameter':
+            lines.append(
+                f'diameter {edge_str(s.data["edge"])} to circle center {s.data["center"]}{o}'
+            );
+            continue
         elif s.kind == 'polygon':
             ids = '-'.join(s.data['ids']); lines.append(f'polygon {ids}{o}'); continue
         elif s.kind in ('triangle','quadrilateral','parallelogram','trapezoid','rectangle','square','rhombus'):

--- a/geoscript_ir/reference.py
+++ b/geoscript_ir/reference.py
@@ -40,6 +40,7 @@ BNF = dedent(
                | 'equal-segments' '(' EdgeList ';' EdgeList ')' Opts?
                | 'parallel-edges' '(' Pair ';' Pair ')' Opts?
                | 'tangent' 'at' ID 'to' 'circle' 'center' ID Opts?
+               | 'diameter' Pair 'to' 'circle' 'center' ID Opts?
                | 'line' ID '-' ID 'tangent' 'to' 'circle' 'center' ID 'at' ID Opts?
                | 'polygon' IdChain Opts?
                | 'triangle' ID '-' ID '-' ID Opts?

--- a/tests/test_bnf.py
+++ b/tests/test_bnf.py
@@ -161,6 +161,12 @@ def test_targets(text, kind, data, opts):
             {},
         ),
         (
+            'diameter A-B to circle center O',
+            'diameter',
+            {'edge': ('A', 'B'), 'center': 'O'},
+            {},
+        ),
+        (
             'polygon A-B-C-D-E',
             'polygon',
             {'ids': ['A', 'B', 'C', 'D', 'E']},

--- a/tests/test_desugar.py
+++ b/tests/test_desugar.py
@@ -221,6 +221,17 @@ def test_intersect_generates_point_on_and_segments():
     assert {s.data['edge'] for s in segments} == {('A', 'D')}
 
 
+def test_diameter_desugars_to_point_on_segment():
+    diameter_stmt = stmt('diameter', {'edge': ('A', 'B'), 'center': 'O'})
+
+    out = desugar(Program([diameter_stmt]))
+
+    generated = [s for s in out.stmts if s.origin == 'desugar(diameter)']
+    assert len(generated) == 1
+    assert generated[0].kind == 'point_on'
+    assert generated[0].data == {'point': 'O', 'path': ('segment', ('A', 'B'))}
+
+
 def test_circle_through_creates_center_and_equal_radii():
     circle = stmt('circle_through', {'ids': ['A', 'B', 'C', 'D']}, {'label': 'omega'})
 

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -17,3 +17,10 @@ def test_segment_length_prints_symbolic_value():
     prog = Program([stmt])
 
     assert print_program(prog) == 'segment A-B [length=sqrt(19)]\n'
+
+
+def test_diameter_prints_statement():
+    stmt = Stmt('diameter', Span(1, 1), {'edge': ('A', 'B'), 'center': 'O'})
+    prog = Program([stmt])
+
+    assert print_program(prog) == 'diameter A-B to circle center O\n'

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -47,6 +47,30 @@ def test_translate_adds_gauges_and_residuals():
     assert any(g.startswith("orientation=") for g in model.gauges)
 
 
+def test_diameter_adds_point_on_segment_residuals():
+    model = _build_model(
+        """
+        scene "Diameter"
+        points A, B, O
+        segment A-B
+        diameter A-B to circle center O
+        """
+    )
+
+    point_on_specs = [
+        spec
+        for spec in model.residuals
+        if spec.key in {
+            "point_on_segment(O,A-B)",
+            "point_on_segment_bounds(O,A-B)",
+        }
+    ]
+
+    keys = {spec.key for spec in point_on_specs}
+    assert keys == {"point_on_segment(O,A-B)", "point_on_segment_bounds(O,A-B)"}
+    assert {spec.source.origin for spec in point_on_specs} == {"desugar(diameter)"}
+
+
 def test_solver_right_triangle_solution_is_stable():
     model = _build_model(
         """


### PR DESCRIPTION
## Summary
- add GeoScript `diameter` statement syntax to the parser, printer, and BNF reference
- desugar each `diameter` statement into a `point_on` segment constraint for the circle center
- cover the new statement with parser, printer, desugar, and solver regression tests

## Testing
- pip install -e ".[test]"
- PYTHONPATH=. pytest tests/test_solver.py::test_diameter_adds_point_on_segment_residuals
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3e5ff66108323bf93608c1b2694c0