### PR TITLE
Convert consistency hotfix suggestions to AST statements

### DIFF
--- a/examples/solve_trapezoid.py
+++ b/examples/solve_trapezoid.py
@@ -10,6 +10,7 @@ from geoscript_ir import (
     ConsistencyWarning,
     desugar_variants,
     parse_program,
+    format_stmt,
     print_program,
     validate,
     normalize_point_coords,
@@ -52,7 +53,11 @@ def main() -> None:
             for warning in warnings:
                 logger.warning("Variant %d consistency warning: %s", idx, warning)
                 for hotfix in warning.hotfixes:
-                    logger.info("Variant %d suggested hotfix: %s", idx, hotfix)
+                    logger.info(
+                        "Variant %d suggested hotfix: %s",
+                        idx,
+                        format_stmt(hotfix),
+                    )
         else:
             logger.info("Variant %d has no consistency warnings", idx)
 
@@ -100,7 +105,7 @@ def main() -> None:
         for warning in best_warnings:
             print(f"  - {warning}")
             for hotfix in warning.hotfixes:
-                print(f"    hotfix: {hotfix}")
+                print(f"    hotfix: {format_stmt(hotfix)}")
     else:
         print("  (none)")
 

--- a/geoscript_ir/__init__.py
+++ b/geoscript_ir/__init__.py
@@ -2,7 +2,7 @@ from .parser import parse_program
 from .validate import validate, ValidationError
 from .desugar import desugar, desugar_variants
 from .consistency import check_consistency, ConsistencyWarning
-from .printer import print_program
+from .printer import print_program, format_stmt
 from .ast import Program, Stmt, Span
 from .reference import BNF, LLM_PROMPT, get_llm_prompt
 from .reference_tikz import GEOSCRIPT_TO_TIKZ_PROMPT
@@ -29,6 +29,7 @@ __all__ = [
     'check_consistency',
     'ConsistencyWarning',
     'print_program',
+    'format_stmt',
     'translate',
     'solve',
     'solve_best_model',

--- a/geoscript_ir/__main__.py
+++ b/geoscript_ir/__main__.py
@@ -10,6 +10,7 @@ from geoscript_ir import (
     desugar_variants,
     generate_tikz_document,
     parse_program,
+    format_stmt,
     print_program,
     validate,
     normalize_point_coords
@@ -82,7 +83,11 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
             for warning in warnings:
                 logger.warning("Variant %d consistency warning: %s", idx, warning)
                 for hotfix in warning.hotfixes:
-                    logger.info("Variant %d suggested hotfix: %s", idx, hotfix)
+                    logger.info(
+                        "Variant %d suggested hotfix: %s",
+                        idx,
+                        format_stmt(hotfix),
+                    )
         else:
             logger.info("Variant %d has no consistency warnings", idx)
 
@@ -130,7 +135,7 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         for warning in best_warnings:
             print(f"  - {warning}")
             for hotfix in warning.hotfixes:
-                print(f"    hotfix: {hotfix}")
+                print(f"    hotfix: {format_stmt(hotfix)}")
     else:
         print("  (none)")
 

--- a/geoscript_ir/demo.py
+++ b/geoscript_ir/demo.py
@@ -1,4 +1,4 @@
-from . import parse_program, validate, desugar, print_program, check_consistency
+from . import parse_program, validate, desugar, print_program, check_consistency, format_stmt
 
 DEMO = """
 scene "Isosceles trapezoid with circumcircle"
@@ -24,7 +24,7 @@ def run():
         for warning in warnings:
             print(f"  - {warning}")
             for hotfix in warning.hotfixes:
-                print(f"    hotfix: {hotfix}")
+                print(f"    hotfix: {format_stmt(hotfix)}")
     else:
         print("  (none)")
 

--- a/geoscript_ir/printer.py
+++ b/geoscript_ir/printer.py
@@ -1,4 +1,4 @@
-from .ast import Program
+from .ast import Program, Stmt
 from .numbers import SymbolicNumber
 from typing import Tuple
 
@@ -145,3 +145,8 @@ def print_program(prog: Program, *, original_only: bool = False) -> str:
         if o and lines:
             lines[-1] += o
     return '\n'.join(lines) + "\n"
+
+
+def format_stmt(stmt: Stmt) -> str:
+    """Return a single-line representation of ``stmt``."""
+    return print_program(Program(stmts=[stmt])).strip()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,4 +41,4 @@ def test_main_writes_tikz_document(tmp_path, monkeypatch):
     cli.main([str(program_path), "--tikz-output-path", str(tikz_path)])
 
     assert tikz_path.read_text(encoding="utf-8") == "tikz document"
-    assert rendered_documents == [("variant", {"A": (0.0, 0.0)}, {})]
+    assert rendered_documents == [("variant", {"A": (0.0, 0.0)}, {"normalize": True})]

--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -22,8 +22,14 @@ angle at A rays A-B A-C
     warning = warnings[0]
     assert warning.kind == 'angle_at'
     assert 'A-B' in warning.message and 'A-C' in warning.message
-    assert 'segment A-B' in warning.hotfixes
-    assert 'segment A-C' in warning.hotfixes
+    assert any(
+        hotfix.kind == 'segment' and hotfix.data['edge'] == ('A', 'B')
+        for hotfix in warning.hotfixes
+    )
+    assert any(
+        hotfix.kind == 'segment' and hotfix.data['edge'] == ('A', 'C')
+        for hotfix in warning.hotfixes
+    )
 
 
 def test_angle_with_segments_has_no_warnings():
@@ -88,7 +94,10 @@ def test_polygon_missing_segments_emits_warning(kind, ids):
         expected_edges.append(f"{a}-{b}")
     for edge in expected_edges:
         assert edge in warning.message
-        assert f'segment {edge}' in warning.hotfixes
+        assert any(
+            hotfix.kind == 'segment' and hotfix.data['edge'] == tuple(edge.split('-'))
+            for hotfix in warning.hotfixes
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- convert consistency warning hotfixes from text into AST statements with metadata
- add a formatter for individual statements and use it to display hotfix suggestions across the CLI and demos
- refresh tests to assert on the new hotfix structure and updated CLI expectations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d54618b40c8323a444ac358dbb37e1