### PR TITLE
Add optional circle endpoint desugaring for diameter statements

### DIFF
--- a/geoscript_ir/desugar.py
+++ b/geoscript_ir/desugar.py
@@ -564,6 +564,20 @@ def desugar_variants(prog: Program) -> List[Program]:
                     source_keys,
                     generated=True,
                 )
+                if s.opts.get('points_on_circle') is True:
+                    for point in segment:
+                        _append(
+                            state,
+                            Stmt(
+                                'point_on',
+                                s.span,
+                                {'point': point, 'path': ('circle', center)},
+                                {},
+                                origin='desugar(diameter)'
+                            ),
+                            source_keys,
+                            generated=True,
+                        )
                 _append(
                     state,
                     Stmt(

--- a/geoscript_ir/validate.py
+++ b/geoscript_ir/validate.py
@@ -48,6 +48,12 @@ def validate(prog: Program) -> None:
         elif k == 'equal_segments':
             if not s.data['lhs'] or not s.data['rhs']:
                 raise ValidationError(f'[line {s.span.line}, col {s.span.col}] equal-segments needs both sides non-empty')
+        elif k == 'diameter':
+            poc = s.opts.get('points_on_circle')
+            if poc not in (None, True, False):
+                raise ValidationError(
+                    f'[line {s.span.line}, col {s.span.col}] diameter points_on_circle must be true|false'
+                )
         elif k == 'circle_through':
             ids = s.data['ids']
             if len(ids) < 3 or len(set(ids)) < 3:

--- a/tests/test_desugar.py
+++ b/tests/test_desugar.py
@@ -239,6 +239,24 @@ def test_diameter_desugars_to_point_on_segment_and_equal_radii():
     }
 
 
+def test_diameter_points_option_places_endpoints_on_circle():
+    diameter_stmt = stmt(
+        'diameter',
+        {'edge': ('A', 'B'), 'center': 'O'},
+        {'points_on_circle': True},
+    )
+
+    out = desugar(Program([diameter_stmt]))
+
+    generated = [s for s in out.stmts if s.origin == 'desugar(diameter)']
+    circle_point_on = [
+        s for s in generated if s.kind == 'point_on' and s.data['path'] == ('circle', 'O')
+    ]
+
+    assert len(circle_point_on) == 2
+    assert {s.data['point'] for s in circle_point_on} == {'A', 'B'}
+
+
 def test_circle_through_creates_center_and_equal_radii():
     circle = stmt('circle_through', {'ids': ['A', 'B', 'C', 'D']}, {'label': 'omega'})
 

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -26,6 +26,18 @@ def test_diameter_prints_statement():
     assert print_program(prog) == 'diameter A-B to circle center O\n'
 
 
+def test_diameter_prints_points_on_circle_option():
+    stmt = Stmt(
+        'diameter',
+        Span(1, 1),
+        {'edge': ('A', 'B'), 'center': 'O'},
+        {'points_on_circle': True},
+    )
+    prog = Program([stmt])
+
+    assert print_program(prog) == 'diameter A-B to circle center O [points_on_circle=true]\n'
+
+
 def test_original_only_skips_generated_statements():
     original = Stmt('segment', Span(1, 1), {'edge': ('A', 'B')})
     generated = Stmt(

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -17,6 +17,7 @@ def test_validate_accepts_valid_program():
             stmt('angle_at', {'at': 'A', 'rays': (('A', 'B'), ('A', 'C'))}),
             stmt('equal_segments', {'lhs': [('A', 'B')], 'rhs': [('C', 'D')]}),
             stmt('circle_through', {'ids': ['A', 'B', 'E']}),
+            stmt('diameter', {'edge': ('A', 'B'), 'center': 'O'}, {'points_on_circle': True}),
             Stmt('rules', Span(7, 1), {}, {'no_solving': True, 'allow_auxiliary': False}),
         ]
     )
@@ -57,6 +58,23 @@ def test_trapezoid_isosceles_must_be_boolean(value, should_error):
         with pytest.raises(ValidationError) as exc:
             validate(prog)
         assert 'trapezoid isosceles' in str(exc.value)
+    else:
+        validate(prog)
+
+
+@pytest.mark.parametrize(
+    'value, should_error',
+    [(None, False), (True, False), (False, False), ('yes', True)],
+)
+def test_diameter_points_on_circle_must_be_boolean(value, should_error):
+    prog = Program([
+        stmt('diameter', {'edge': ('A', 'B'), 'center': 'O'}, {'points_on_circle': value})
+    ])
+
+    if should_error:
+        with pytest.raises(ValidationError) as exc:
+            validate(prog)
+        assert 'diameter points_on_circle' in str(exc.value)
     else:
         validate(prog)
 


### PR DESCRIPTION
## Summary
- add a `points_on_circle` option that desugars diameter statements into circle point constraints for each endpoint
- validate the new option and cover it with printer/desugar tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5b5ba42c88323b7966efa117a0ea2