### PR TITLE
Ensure diameter endpoints lie on their circle automatically

### DIFF
--- a/geoscript_ir/desugar.py
+++ b/geoscript_ir/desugar.py
@@ -564,20 +564,20 @@ def desugar_variants(prog: Program) -> List[Program]:
                     source_keys,
                     generated=True,
                 )
-                if s.opts.get('points_on_circle') is True:
-                    for point in segment:
-                        _append(
-                            state,
-                            Stmt(
-                                'point_on',
-                                s.span,
-                                {'point': point, 'path': ('circle', center)},
-                                {},
-                                origin='desugar(diameter)'
-                            ),
-                            source_keys,
-                            generated=True,
-                        )
+                for i, point in enumerate(segment):
+                    radius_point = segment[1 - i]
+                    _append(
+                        state,
+                        Stmt(
+                            'point_on',
+                            s.span,
+                            {'point': point, 'path': ('circle', center)},
+                            {'radius_point': radius_point},
+                            origin='desugar(diameter)'
+                        ),
+                        source_keys,
+                        generated=True,
+                    )
                 _append(
                     state,
                     Stmt(

--- a/geoscript_ir/validate.py
+++ b/geoscript_ir/validate.py
@@ -49,10 +49,9 @@ def validate(prog: Program) -> None:
             if not s.data['lhs'] or not s.data['rhs']:
                 raise ValidationError(f'[line {s.span.line}, col {s.span.col}] equal-segments needs both sides non-empty')
         elif k == 'diameter':
-            poc = s.opts.get('points_on_circle')
-            if poc not in (None, True, False):
+            for key in s.opts:
                 raise ValidationError(
-                    f'[line {s.span.line}, col {s.span.col}] diameter points_on_circle must be true|false'
+                    f'[line {s.span.line}, col {s.span.col}] diameter does not support option "{key}"'
                 )
         elif k == 'circle_through':
             ids = s.data['ids']

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -26,18 +26,6 @@ def test_diameter_prints_statement():
     assert print_program(prog) == 'diameter A-B to circle center O\n'
 
 
-def test_diameter_prints_points_on_circle_option():
-    stmt = Stmt(
-        'diameter',
-        Span(1, 1),
-        {'edge': ('A', 'B'), 'center': 'O'},
-        {'points_on_circle': True},
-    )
-    prog = Program([stmt])
-
-    assert print_program(prog) == 'diameter A-B to circle center O [points_on_circle=true]\n'
-
-
 def test_original_only_skips_generated_statements():
     original = Stmt('segment', Span(1, 1), {'edge': ('A', 'B')})
     generated = Stmt(

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -76,6 +76,14 @@ def test_diameter_adds_point_on_segment_and_radius_residuals():
     assert len(equal_segments_specs) == 1
     assert equal_segments_specs[0].source.origin == "desugar(diameter)"
 
+    circle_specs = [
+        spec
+        for spec in model.residuals
+        if spec.key in {"point_on_circle(A,O)", "point_on_circle(B,O)"}
+    ]
+    assert {spec.key for spec in circle_specs} == {"point_on_circle(A,O)", "point_on_circle(B,O)"}
+    assert {spec.source.origin for spec in circle_specs} == {"desugar(diameter)"}
+
 
 def test_solver_right_triangle_solution_is_stable():
     model = _build_model(

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -17,7 +17,7 @@ def test_validate_accepts_valid_program():
             stmt('angle_at', {'at': 'A', 'rays': (('A', 'B'), ('A', 'C'))}),
             stmt('equal_segments', {'lhs': [('A', 'B')], 'rhs': [('C', 'D')]}),
             stmt('circle_through', {'ids': ['A', 'B', 'E']}),
-            stmt('diameter', {'edge': ('A', 'B'), 'center': 'O'}, {'points_on_circle': True}),
+            stmt('diameter', {'edge': ('A', 'B'), 'center': 'O'}),
             Stmt('rules', Span(7, 1), {}, {'no_solving': True, 'allow_auxiliary': False}),
         ]
     )
@@ -62,21 +62,15 @@ def test_trapezoid_isosceles_must_be_boolean(value, should_error):
         validate(prog)
 
 
-@pytest.mark.parametrize(
-    'value, should_error',
-    [(None, False), (True, False), (False, False), ('yes', True)],
-)
-def test_diameter_points_on_circle_must_be_boolean(value, should_error):
+def test_diameter_rejects_options():
     prog = Program([
-        stmt('diameter', {'edge': ('A', 'B'), 'center': 'O'}, {'points_on_circle': value})
+        stmt('diameter', {'edge': ('A', 'B'), 'center': 'O'}, {'points_on_circle': True})
     ])
 
-    if should_error:
-        with pytest.raises(ValidationError) as exc:
-            validate(prog)
-        assert 'diameter points_on_circle' in str(exc.value)
-    else:
+    with pytest.raises(ValidationError) as exc:
         validate(prog)
+
+    assert 'diameter does not support option "points_on_circle"' in str(exc.value)
 
 
 def test_polygon_vertices_must_be_unique():


### PR DESCRIPTION
## Summary
- always generate point-on-circle statements for diameter endpoints and provide solver radius references
- reject all diameter statement options during validation now that points lie on the circle by default
- update desugaring, printer, solver, and validation tests to reflect the new behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5b96eafe88323943cef6976ea9122