### PR TITLE
Desugar midpoint marks into equal segments

### DIFF
--- a/geoscript_ir/desugar.py
+++ b/geoscript_ir/desugar.py
@@ -521,6 +521,29 @@ def desugar_variants(prog: Program) -> List[Program]:
                         source_keys,
                         generated=True,
                     )
+        elif s.kind == 'point_on':
+            if s.opts.get('mark') == 'midpoint':
+                point = s.data.get('point')
+                path = s.data.get('path')
+                if isinstance(point, str) and isinstance(path, (list, tuple)) and len(path) == 2:
+                    path_kind, payload = path
+                    if path_kind == 'segment' and isinstance(payload, (list, tuple)) and len(payload) == 2:
+                        start, end = payload
+                        if isinstance(start, str) and isinstance(end, str):
+                            seg1 = edge(point, start)
+                            seg2 = edge(point, end)
+                            for state in states:
+                                _append(
+                                    state,
+                                    Stmt(
+                                        'equal_segments',
+                                        s.span,
+                                        {'lhs': [seg1], 'rhs': [seg2]},
+                                        origin='desugar(midpoint)'
+                                    ),
+                                    source_keys,
+                                    generated=True,
+                                )
         elif s.kind == 'intersect':
             path1 = s.data['path1']
             path2 = s.data['path2']

--- a/tests/test_desugar.py
+++ b/tests/test_desugar.py
@@ -33,6 +33,27 @@ def test_desugar_skips_duplicate_equal_segments():
     assert eq[0].origin == 'source'
 
 
+def test_point_on_segment_midpoint_creates_equal_segments():
+    midpoint_stmt = stmt(
+        'point_on',
+        {'point': 'M', 'path': ('segment', ('B', 'C'))},
+        {'mark': 'midpoint'},
+    )
+
+    out = desugar(Program([midpoint_stmt]))
+
+    midpoint_generated = [
+        s
+        for s in out.stmts
+        if s.kind == 'equal_segments' and s.origin == 'desugar(midpoint)'
+    ]
+    assert len(midpoint_generated) == 1
+    assert midpoint_generated[0].data == {
+        'lhs': [('M', 'B')],
+        'rhs': [('M', 'C')],
+    }
+
+
 def test_polygon_desugars_into_segments():
     prog = Program([stmt('polygon', {'ids': ['A', 'B', 'C']})])
 


### PR DESCRIPTION
## Summary
- remove the unused midpoint canonical key as midpoint markers expand to existing statements
- translate midpoint point-on markers into equal segments between the midpoint and segment endpoints
- adjust the desugar unit test to reflect the equal-segment constraint

## Testing
- pytest tests/test_desugar.py::test_point_on_segment_midpoint_creates_equal_segments

------
https://chatgpt.com/codex/tasks/task_e_68d653d828908323afb91daf832d0a4e