### PR TITLE
Add consistency warning for equal-segments without segments

### DIFF
--- a/geoscript_ir/consistency.py
+++ b/geoscript_ir/consistency.py
@@ -117,6 +117,30 @@ def check_consistency(prog: Program) -> List[ConsistencyWarning]:
                         hotfixes=hotfixes,
                     )
                 )
+        elif stmt.kind == 'equal_segments':
+            segments = list(stmt.data['lhs']) + list(stmt.data['rhs'])
+            missing_edges: List[Ray] = []
+            for edge in segments:
+                edge_norm = _normalize_edge(edge)
+                if edge_norm not in source_segments:
+                    missing_edges.append(edge_norm)
+            if missing_edges:
+                missing_edges = list(dict.fromkeys(missing_edges))
+                missing_text = ', '.join(_format_ray(edge) for edge in missing_edges)
+                hotfixes = [_segment_hotfix(edge, stmt.span) for edge in missing_edges]
+                message = (
+                    f"[line {stmt.span.line}, col {stmt.span.col}] {stmt.kind} "
+                    f"missing segments: {missing_text}"
+                )
+                warnings.append(
+                    ConsistencyWarning(
+                        line=stmt.span.line,
+                        col=stmt.span.col,
+                        kind=stmt.kind,
+                        message=message,
+                        hotfixes=hotfixes,
+                    )
+                )
         elif stmt.kind in _POLYGON_KINDS:
             ids = stmt.data['ids']
             missing_edges: List[Ray] = []

--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -119,3 +119,38 @@ def test_polygon_with_segments_has_no_warnings(kind, ids):
     warnings = check_consistency(prog)
     assert warnings == []
 
+
+def test_equal_segments_missing_segments_emits_warning():
+    text = """
+scene "Equality"
+points A, B, C
+equal-segments (A-B ; A-C)
+"""
+    prog = run_pipeline(text)
+    warnings = check_consistency(prog)
+    assert warnings
+    warning = warnings[0]
+    assert warning.kind == 'equal_segments'
+    assert 'A-B' in warning.message and 'A-C' in warning.message
+    assert any(
+        hotfix.kind == 'segment' and hotfix.data['edge'] == ('A', 'B')
+        for hotfix in warning.hotfixes
+    )
+    assert any(
+        hotfix.kind == 'segment' and hotfix.data['edge'] == ('A', 'C')
+        for hotfix in warning.hotfixes
+    )
+
+
+def test_equal_segments_with_segments_has_no_warnings():
+    text = """
+scene "Equality"
+points A, B, C
+segment A-B
+segment A-C
+equal-segments (A-B ; A-C)
+"""
+    prog = run_pipeline(text)
+    warnings = check_consistency(prog)
+    assert warnings == []
+


### PR DESCRIPTION
## Summary
- ensure consistency checks verify `equal-segments` statements reference existing segments
- supply segment hotfixes when the supporting segments are missing
- add regression tests covering missing and satisfied `equal-segments`

## Testing
- pip install -e .[test]
- pytest tests/test_consistency.py

------
https://chatgpt.com/codex/tasks/task_e_68d65aa771f48323bc825f6403e9fcef