### PR TITLE
Enforce bracketed rules options

### DIFF
--- a/docs/bnf.txt
+++ b/docs/bnf.txt
@@ -1,0 +1,73 @@
+Program   := { Stmt }
+Stmt      := Scene | Layout | Points | Obj | Placement | Annot | Target | Rules | Comment
+
+Scene     := 'scene' STRING
+Layout    := 'layout' 'canonical=' ID 'scale=' NUMBER
+Points    := 'points' ID { ',' ID }
+
+Annot     := 'label point' ID Opts?
+           | 'sidelabel' Pair STRING Opts?
+
+Target    := 'target'
+             ( 'angle' Angle3 Opts?
+             | 'length' Pair Opts?
+             | 'point' ID Opts?
+             | 'circle' '(' STRING ')' Opts?
+             | 'area' '(' STRING ')' Opts?
+             | 'arc' ID '-' ID 'on' 'circle' 'center' ID Opts?
+             )
+
+Obj       := 'segment'      Pair Opts?
+           | 'ray'          Pair Opts?
+           | 'line'         Pair Opts?
+           | 'circle' 'center' ID 'radius-through' ID Opts?
+           | 'circle' 'through' '(' IdList ')' Opts?
+           | 'circumcircle' 'of' IdChain Opts?
+           | 'incircle'     'of' IdChain Opts?
+           | 'perpendicular' 'at' ID 'to' Pair 'foot' ID Opts?
+           | 'parallel'      'through' ID 'to' Pair Opts?
+           | 'median'        'from' ID 'to' Pair 'midpoint' ID Opts?
+           | 'angle'         Angle3 Opts?
+           | 'right-angle'   Angle3 Opts?
+           | 'equal-segments' '(' EdgeList ';' EdgeList ')' Opts?
+           | 'parallel-edges' '(' Pair ';' Pair ')' Opts?
+           | 'tangent' 'at' ID 'to' 'circle' 'center' ID Opts?
+           | 'diameter'      Pair 'to' 'circle' 'center' ID
+           | 'line' ID '-' ID 'tangent' 'to' 'circle' 'center' ID 'at' ID Opts?
+           | 'polygon'       IdChain Opts?
+           | 'triangle'      ID '-' ID '-' ID Opts?
+           | 'quadrilateral' ID '-' ID '-' ID '-' ID Opts?
+           | 'parallelogram' ID '-' ID '-' ID '-' ID Opts?
+           | 'trapezoid'     ID '-' ID '-' ID '-' ID Opts?
+           | 'rectangle'     ID '-' ID '-' ID '-' ID Opts?
+           | 'square'        ID '-' ID '-' ID '-' ID Opts?
+           | 'rhombus'       ID '-' ID '-' ID '-' ID Opts?
+
+Placement := 'point' ID 'on' Path Opts?
+           | 'intersect' '(' Path ')' 'with' '(' Path ')' 'at' ID (',' ID)? Opts?
+           | 'midpoint' ID 'of' Pair Opts?
+           | 'foot' ID 'from' ID 'to' Pair Opts?
+
+Path      := 'line'    Pair
+           | 'ray'     Pair
+           | 'segment' Pair
+           | 'circle' 'center' ID
+           | 'angle-bisector' Angle3 ('external')?
+           | 'median'  'from' ID 'to' Pair
+           | 'perpendicular' 'at' ID 'to' Pair
+
+Rules     := 'rules' Opts
+
+Comment   := '#' { any-char }
+
+EdgeList  := Pair { ',' Pair }
+IdList    := ID { ',' ID }
+IdChain   := ID '-' ID { '-' ID }
+Pair      := ID '-' ID
+Angle3    := ID '-' ID '-' ID
+
+Opts      := '[' KeyVal { (',' | ' ') KeyVal } ']'
+KeyVal    := KEY '=' (NUMBER | STRING | BOOLEAN | ID | ID '-' ID | SQRT | PRODUCT)
+SQRT      := 'sqrt' '(' NUMBER ')'
+PRODUCT   := NUMBER '*' SQRT
+BOOLEAN   := 'true' | 'false'

--- a/examples/solve_trapezoid.py
+++ b/examples/solve_trapezoid.py
@@ -27,7 +27,7 @@ trapezoid A-B-C-D [bases=A-D isosceles=true]
 circle through (A, B, C, D)
 segment A-B [length=4]
 target angle B-A-D
-rules no_solving=true
+rules [no_solving=true]
 """
 
 

--- a/geoscript_ir/demo.py
+++ b/geoscript_ir/demo.py
@@ -8,7 +8,7 @@ circle through (A, B, C, D)
 points E
 angle A-E-B
 target angle B-A-D
-rules no_solving=true
+rules [no_solving=true]
 """
 
 def run():

--- a/geoscript_ir/printer.py
+++ b/geoscript_ir/printer.py
@@ -152,8 +152,10 @@ def print_program(prog: Program, *, original_only: bool = False) -> str:
             lines.append(f'parallel-edges ({edge_str(a)} ; {edge_str(b)}){o}')
             continue
         elif s.kind == 'rules':
+            if not s.opts:
+                raise ValueError('rules statement requires at least one option')
             parts = [f'{k}={"true" if s.opts[k] else "false"}' for k in sorted(s.opts.keys())]
-            lines.append('rules ' + ' '.join(parts)); continue
+            lines.append('rules [' + ' '.join(parts) + ']'); continue
         else:
             lines.append(f'# [unknown kind {s.kind}]'); continue
         if o and lines:

--- a/geoscript_ir/reference.py
+++ b/geoscript_ir/reference.py
@@ -12,55 +12,59 @@ BNF = dedent(
     Points    := 'points' ID { ',' ID }
 
     Annot     := 'label point' ID Opts?
-              | 'sidelabel' Pair STRING Opts?
+               | 'sidelabel' Pair STRING Opts?
 
     Target    := 'target'
-                 ( 'angle' Angle3
-                 | 'length' Pair
-                 | 'point' ID
-                 | 'circle' '(' STRING ')'
-                 | 'area' '(' STRING ')'
+                 ( 'angle' Angle3 Opts?
+                 | 'length' Pair Opts?
+                 | 'point' ID Opts?
+                 | 'circle' '(' STRING ')' Opts?
+                 | 'area' '(' STRING ')' Opts?
                  | 'arc' ID '-' ID 'on' 'circle' 'center' ID Opts?
                  )
 
-    Obj       := 'segment' Pair Opts?
-               | 'ray'     Pair Opts?
-               | 'line'    Pair Opts?
+    Obj       := 'segment'      Pair Opts?
+               | 'ray'          Pair Opts?
+               | 'line'         Pair Opts?
                | 'circle' 'center' ID 'radius-through' ID Opts?
                | 'circle' 'through' '(' IdList ')' Opts?
                | 'circumcircle' 'of' IdChain Opts?
-               | 'incircle'    'of' IdChain Opts?
+               | 'incircle'     'of' IdChain Opts?
                | 'perpendicular' 'at' ID 'to' Pair 'foot' ID Opts?
-               | 'parallel' 'through' ID 'to' Pair Opts?
-               | 'median'  'from' ID 'to' Pair 'midpoint' ID Opts?
-               | 'angle' Angle3 Opts?
-               | 'right-angle' Angle3 Opts?
+               | 'parallel'      'through' ID 'to' Pair Opts?
+               | 'median'        'from' ID 'to' Pair 'midpoint' ID Opts?
+               | 'angle'         Angle3 Opts?
+               | 'right-angle'   Angle3 Opts?
                | 'equal-segments' '(' EdgeList ';' EdgeList ')' Opts?
                | 'parallel-edges' '(' Pair ';' Pair ')' Opts?
                | 'tangent' 'at' ID 'to' 'circle' 'center' ID Opts?
-               | 'diameter' Pair 'to' 'circle' 'center' ID Opts?
+               | 'diameter'      Pair 'to' 'circle' 'center' ID
                | 'line' ID '-' ID 'tangent' 'to' 'circle' 'center' ID 'at' ID Opts?
-               | 'polygon' IdChain Opts?
-               | 'triangle' ID '-' ID '-' ID Opts?
+               | 'polygon'       IdChain Opts?
+               | 'triangle'      ID '-' ID '-' ID Opts?
                | 'quadrilateral' ID '-' ID '-' ID '-' ID Opts?
                | 'parallelogram' ID '-' ID '-' ID '-' ID Opts?
-               | 'trapezoid' ID '-' ID '-' ID '-' ID Opts?
-               | 'rectangle' ID '-' ID '-' ID '-' ID Opts?
-               | 'square' ID '-' ID '-' ID '-' ID Opts?
-               | 'rhombus' ID '-' ID '-' ID '-' ID Opts?
+               | 'trapezoid'     ID '-' ID '-' ID '-' ID Opts?
+               | 'rectangle'     ID '-' ID '-' ID '-' ID Opts?
+               | 'square'        ID '-' ID '-' ID '-' ID Opts?
+               | 'rhombus'       ID '-' ID '-' ID '-' ID Opts?
 
-    Placement := 'point' ID 'on' Path
+    Placement := 'point' ID 'on' Path Opts?
                | 'intersect' '(' Path ')' 'with' '(' Path ')' 'at' ID (',' ID)? Opts?
                | 'midpoint' ID 'of' Pair Opts?
                | 'foot' ID 'from' ID 'to' Pair Opts?
 
     Path      := 'line'    Pair
-                | 'ray'     Pair
-                | 'segment' Pair
-                | 'circle' 'center' ID
-                | 'angle-bisector' Angle3 ('external')?
-                | 'median'  'from' ID 'to' Pair
-                | 'perpendicular' 'at' ID 'to' Pair
+               | 'ray'     Pair
+               | 'segment' Pair
+               | 'circle' 'center' ID
+               | 'angle-bisector' Angle3 ('external')?
+               | 'median'  'from' ID 'to' Pair
+               | 'perpendicular' 'at' ID 'to' Pair
+
+    Rules     := 'rules' Opts
+
+    Comment   := '#' { any-char }
 
     EdgeList  := Pair { ',' Pair }
     IdList    := ID { ',' ID }
@@ -68,8 +72,11 @@ BNF = dedent(
     Pair      := ID '-' ID
     Angle3    := ID '-' ID '-' ID
 
-    Opts      := '[' KeyVal { ' ' KeyVal } ']'
-    KeyVal    := KEY '=' (VALUE | STRING)
+    Opts      := '[' KeyVal { (',' | ' ') KeyVal } ']'
+    KeyVal    := KEY '=' (NUMBER | STRING | BOOLEAN | ID | ID '-' ID | SQRT | PRODUCT)
+    SQRT      := 'sqrt' '(' NUMBER ')'
+    PRODUCT   := NUMBER '*' SQRT
+    BOOLEAN   := 'true' | 'false'
     """
 ).strip()
 

--- a/geoscript_ir/solver.py
+++ b/geoscript_ir/solver.py
@@ -653,7 +653,7 @@ def _build_quadrilateral_family(stmt: Stmt, index: Dict[PointName, int]) -> List
     if len(ids) != 4:
         return []
 
-    key_base = f"{stmt.kind}({"-".join(ids)})"
+    key_base = f"{stmt.kind}({'-'.join(ids)})"
     specs: List[ResidualSpec] = []
 
     def convex_func(x: np.ndarray) -> np.ndarray:

--- a/tests/samples/demo1.geo
+++ b/tests/samples/demo1.geo
@@ -4,4 +4,4 @@ points A, B, C, D
 trapezoid A-B-C-D [bases=A-D isosceles=true]
 circle through (A, B, C, D)
 target angle B-A-D
-rules no_solving=true
+rules [no_solving=true]

--- a/tests/test_bnf.py
+++ b/tests/test_bnf.py
@@ -304,3 +304,18 @@ def test_rules():
     stmt = parse_single('rules [no_solving=true allow_dashed=false]')
     assert stmt.kind == 'rules'
     assert stmt.opts == {'allow_dashed': False, 'no_solving': True}
+
+
+def test_rules_requires_bracket_syntax():
+    with pytest.raises(SyntaxError):
+        parse_program('rules no_solving=true')
+
+
+def test_diameter_rejects_options_in_parser():
+    with pytest.raises(SyntaxError):
+        parse_program('diameter A-B to circle center O [mark=true]')
+
+
+def test_empty_options_block_rejected():
+    with pytest.raises(SyntaxError):
+        parse_program('segment A-B []')

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -26,6 +26,13 @@ def test_diameter_prints_statement():
     assert print_program(prog) == 'diameter A-B to circle center O\n'
 
 
+def test_rules_prints_bracketed_options():
+    stmt = Stmt('rules', Span(1, 1), {}, {'allow_auxiliary': False, 'no_solving': True})
+    prog = Program([stmt])
+
+    assert print_program(prog) == 'rules [allow_auxiliary=false no_solving=true]\n'
+
+
 def test_original_only_skips_generated_statements():
     original = Stmt('segment', Span(1, 1), {'edge': ('A', 'B')})
     generated = Stmt(

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -10,7 +10,7 @@ points A, B, C, D
 trapezoid A-B-C-D [bases=A-D isosceles=true]
 circle through (A, B, C, D)
 target angle B-A-D
-rules no_solving=true
+rules [no_solving=true]
 '''
     prog = parse_program(text)
     validate(prog)


### PR DESCRIPTION
## Summary
- enforce the parser requirements so rules statements use bracketed options, empty option blocks are rejected, and diameter statements cannot carry options
- update the printer and bundled sample scenes to emit rules with bracketed options to match the grammar
- add regression tests covering the new parser errors and the printer output for rules statements

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3890e9d7c8327b117a3234aaa6a26