### PR TITLE
Add solver and grammar support for new GeoScript constraints

### DIFF
--- a/docs/bnf.txt
+++ b/docs/bnf.txt
@@ -42,6 +42,10 @@ Obj       := 'segment'      Pair Opts?
            | 'rectangle'     ID '-' ID '-' ID '-' ID Opts?
            | 'square'        ID '-' ID '-' ID '-' ID Opts?
            | 'rhombus'       ID '-' ID '-' ID '-' ID Opts?
+           | 'collinear' '(' IdList ')' Opts?
+           | 'concyclic' '(' IdList ')' Opts?
+           | 'equal-angles' '(' AngleList ';' AngleList ')' Opts?
+           | 'ratio' '(' Pair ':' Pair '=' NUMBER ':' NUMBER ')' Opts?
 
 Placement := 'point' ID 'on' Path Opts?
            | 'intersect' '(' Path ')' 'with' '(' Path ')' 'at' ID (',' ID)? Opts?
@@ -55,6 +59,8 @@ Path      := 'line'    Pair
            | 'angle-bisector' Angle3 ('external')?
            | 'median'  'from' ID 'to' Pair
            | 'perpendicular' 'at' ID 'to' Pair
+           | 'perp-bisector' 'of' Pair
+           | 'parallel' 'through' ID 'to' Pair
 
 Rules     := 'rules' Opts
 
@@ -63,11 +69,15 @@ Comment   := '#' { any-char }
 EdgeList  := Pair { ',' Pair }
 IdList    := ID { ',' ID }
 IdChain   := ID '-' ID { '-' ID }
+AngleList := Angle3 { ',' Angle3 }
 Pair      := ID '-' ID
 Angle3    := ID '-' ID '-' ID
 
 Opts      := '[' KeyVal { (',' | ' ') KeyVal } ']'
 KeyVal    := KEY '=' (NUMBER | STRING | BOOLEAN | ID | ID '-' ID | SQRT | PRODUCT)
+           | 'choose' '=' ('near' | 'far' | 'left' | 'right' | 'cw' | 'ccw')
+           | 'anchor' '=' ID
+           | 'ref'     '=' Pair
 SQRT      := 'sqrt' '(' NUMBER ')'
 PRODUCT   := NUMBER '*' SQRT
 BOOLEAN   := 'true' | 'false'

--- a/geoscript_ir/lexer.py
+++ b/geoscript_ir/lexer.py
@@ -15,6 +15,7 @@ SYMBOLS = {
     ';': 'SEMI',
     '=': 'EQUAL',
     '*': 'STAR',
+    ':': 'COLON',
 }
 
 WS = ' \t\r'

--- a/geoscript_ir/printer.py
+++ b/geoscript_ir/printer.py
@@ -33,6 +33,14 @@ def path_str(path: Tuple[str, object]) -> str:
         if isinstance(to_edge, (list, tuple)):
             return f'median from {frm} to {edge_str(to_edge)}'
         return f'median from {frm}'
+    if kind == 'perp-bisector' and isinstance(payload, (list, tuple)):
+        return f'perp-bisector of {edge_str(tuple(payload))}'
+    if kind == 'parallel' and isinstance(payload, dict):
+        through = payload.get('through', '')
+        to_edge = payload.get('to')
+        if isinstance(to_edge, (list, tuple)):
+            return f'parallel through {through} to {edge_str(tuple(to_edge))}'
+        return f'parallel through {through}'
     return f'# [unknown path {kind}]'
 
 def print_program(prog: Program, *, original_only: bool = False) -> str:
@@ -111,6 +119,28 @@ def print_program(prog: Program, *, original_only: bool = False) -> str:
             lhs = ', '.join(edge_str(e) for e in s.data['lhs'])
             rhs = ', '.join(edge_str(e) for e in s.data['rhs'])
             lines.append(f'equal-segments ({lhs} ; {rhs})')
+        elif s.kind == 'collinear':
+            ids = ', '.join(s.data['points'])
+            lines.append(f'collinear ({ids})')
+        elif s.kind == 'concyclic':
+            ids = ', '.join(s.data['points'])
+            lines.append(f'concyclic ({ids})')
+        elif s.kind == 'equal_angles':
+            lhs = ', '.join(angle_str(tuple(ang)) for ang in s.data['lhs'])
+            rhs = ', '.join(angle_str(tuple(ang)) for ang in s.data['rhs'])
+            lines.append(f'equal-angles ({lhs} ; {rhs})')
+        elif s.kind == 'ratio':
+            left, right = s.data['edges']
+            a, b = s.data['ratio']
+
+            def _fmt_ratio_part(val):
+                if isinstance(val, float) and val.is_integer():
+                    return str(int(val))
+                return str(val)
+
+            lines.append(
+                f'ratio ({edge_str(left)} : {edge_str(right)} = {_fmt_ratio_part(a)} : {_fmt_ratio_part(b)})'
+            )
         elif s.kind == 'tangent_at':
             lines.append(f'tangent at {s.data["at"]} to circle center {s.data["center"]}{o}'); continue
         elif s.kind == 'diameter':

--- a/geoscript_ir/reference.py
+++ b/geoscript_ir/reference.py
@@ -48,6 +48,10 @@ BNF = dedent(
                | 'rectangle'     ID '-' ID '-' ID '-' ID Opts?
                | 'square'        ID '-' ID '-' ID '-' ID Opts?
                | 'rhombus'       ID '-' ID '-' ID '-' ID Opts?
+               | 'collinear' '(' IdList ')' Opts?
+               | 'concyclic' '(' IdList ')' Opts?
+               | 'equal-angles' '(' AngleList ';' AngleList ')' Opts?
+               | 'ratio' '(' Pair ':' Pair '=' NUMBER ':' NUMBER ')' Opts?
 
     Placement := 'point' ID 'on' Path Opts?
                | 'intersect' '(' Path ')' 'with' '(' Path ')' 'at' ID (',' ID)? Opts?
@@ -61,6 +65,8 @@ BNF = dedent(
                | 'angle-bisector' Angle3 ('external')?
                | 'median'  'from' ID 'to' Pair
                | 'perpendicular' 'at' ID 'to' Pair
+               | 'perp-bisector' 'of' Pair
+               | 'parallel' 'through' ID 'to' Pair
 
     Rules     := 'rules' Opts
 
@@ -69,11 +75,15 @@ BNF = dedent(
     EdgeList  := Pair { ',' Pair }
     IdList    := ID { ',' ID }
     IdChain   := ID '-' ID { '-' ID }
+    AngleList := Angle3 { ',' Angle3 }
     Pair      := ID '-' ID
     Angle3    := ID '-' ID '-' ID
 
     Opts      := '[' KeyVal { (',' | ' ') KeyVal } ']'
     KeyVal    := KEY '=' (NUMBER | STRING | BOOLEAN | ID | ID '-' ID | SQRT | PRODUCT)
+               | 'choose' '=' ('near' | 'far' | 'left' | 'right' | 'cw' | 'ccw')
+               | 'anchor' '=' ID
+               | 'ref'     '=' Pair
     SQRT      := 'sqrt' '(' NUMBER ')'
     PRODUCT   := NUMBER '*' SQRT
     BOOLEAN   := 'true' | 'false'

--- a/tests/test_bnf.py
+++ b/tests/test_bnf.py
@@ -137,6 +137,30 @@ def test_targets(text, kind, data, opts):
             {},
         ),
         (
+            'collinear (A, B, C)',
+            'collinear',
+            {'points': ['A', 'B', 'C']},
+            {},
+        ),
+        (
+            'concyclic (A, B, C, D)',
+            'concyclic',
+            {'points': ['A', 'B', 'C', 'D']},
+            {},
+        ),
+        (
+            'equal-angles (A-B-C ; D-E-F)',
+            'equal_angles',
+            {'lhs': [('A', 'B', 'C')], 'rhs': [('D', 'E', 'F')]},
+            {},
+        ),
+        (
+            'ratio (A-B : C-D = 2 : 3)',
+            'ratio',
+            {'edges': [('A', 'B'), ('C', 'D')], 'ratio': (2.0, 3.0)},
+            {},
+        ),
+        (
             'tangent at A to circle center O',
             'tangent_at',
             {'at': 'A', 'center': 'O'},
@@ -220,6 +244,20 @@ def test_placements():
     assert pt_on_median.data == {
         'point': 'T',
         'path': ('median', {'frm': 'C', 'to': ('A', 'B')}),
+    }
+
+    pt_on_perp_bis = parse_single('point U on perp-bisector of A-B')
+    assert pt_on_perp_bis.kind == 'point_on'
+    assert pt_on_perp_bis.data == {
+        'point': 'U',
+        'path': ('perp-bisector', ('A', 'B')),
+    }
+
+    pt_on_parallel = parse_single('point V on parallel through C to A-B')
+    assert pt_on_parallel.kind == 'point_on'
+    assert pt_on_parallel.data == {
+        'point': 'V',
+        'path': ('parallel', {'through': 'C', 'to': ('A', 'B')}),
     }
 
     inter = parse_single('intersect (line A-B) with (circle center O) at P, Q [type=external]')


### PR DESCRIPTION
## Summary
- expand the GeoScript grammar and documentation to cover collinear, concyclic, equal-angle, and segment ratio statements along with new path forms
- implement parsing, printing, validation, and solver residuals for the new constructs including parallel/perp-bisector paths and circle-based constraints
- extend parser and solver unit tests to exercise the newly supported statements and residual builders

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3944d99dc83278125819a8cad7947