### PR TITLE
Implement deterministic derivation cross-check module

### DIFF
--- a/geoscript_ir/__init__.py
+++ b/geoscript_ir/__init__.py
@@ -19,6 +19,7 @@ from .solver import (
     normalize_point_coords,
     score_solution
 )
+from .ddc import derive_and_check
 
 __all__ = [
     'parse_program',
@@ -39,6 +40,7 @@ __all__ = [
     'Solution',
     'VariantSolveResult',
     'normalize_point_coords',
+    'derive_and_check',
     'Program',
     'Stmt',
     'Span',

--- a/geoscript_ir/ddc.py
+++ b/geoscript_ir/ddc.py
@@ -1,0 +1,961 @@
+"""Deterministic Derivation & Cross-Check (DDC).
+
+This module implements the specification from ``main.md`` (§16).  The goal is
+to deterministically derive coordinates for points that can be computed without
+numerical optimisation and compare the candidates against the numeric solution
+returned by :mod:`geoscript_ir.solver`.
+
+The implementation focuses on the core rule library described in the spec.
+Rules are intentionally small and pure: every rule takes already-known points
+and optionally paths/circles, produces a set of candidate coordinates, applies
+hard filters (segment/ray membership, perpendicular requirements, …), and then
+uses soft selectors encoded in GeoScript options to bias the choice.  The
+resulting candidate sets are compared with the solver output to expose wrong
+branches early.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import atan2, sqrt
+from typing import Callable, Dict, Iterable, List, Literal, Optional, Sequence, Set, Tuple, TypedDict
+
+from .ast import Program, Stmt
+from .solver import Solution
+
+Point = Tuple[float, float]
+PointName = str
+
+_EPS = 1e-12
+_MEMBERSHIP_EPS = 1e-9
+
+
+class DerivedPointReport(TypedDict, total=False):
+    rule: str
+    inputs: List[str]
+    candidates: List[Point]
+    chosen_by: Literal[
+        "unique",
+        "opts",
+        "ray/segment filter",
+        "closest-to-solver",
+        "undetermined",
+    ]
+    match: Literal["yes", "no"]
+    dist: float
+    notes: List[str]
+
+
+class DerivationGraphExport(TypedDict, total=False):
+    nodes: List[str]
+    edges: List[Tuple[str, str]]
+    topo_order: List[str]
+
+
+class DerivationReport(TypedDict, total=False):
+    status: Literal["ok", "mismatch", "ambiguous", "partial"]
+    summary: str
+    points: Dict[str, DerivedPointReport]
+    unused_facts: List[str]
+    graph: DerivationGraphExport
+
+
+@dataclass
+class CircleInfo:
+    center: str
+    through: str
+    stmt: Stmt
+
+
+@dataclass
+class LineSpec:
+    kind: Literal["line", "ray", "segment"]
+    anchor: Point
+    direction: Point
+    endpoints: Tuple[str, str]
+
+
+@dataclass
+class CircleSpec:
+    center: Point
+    radius: float
+    center_name: str
+    through_name: Optional[str]
+
+
+@dataclass
+class Rule:
+    name: str
+    point: str
+    inputs: Set[str]
+    multiplicity: Literal[1, 2]
+    solver: Callable[["EvalContext"], "RuleOutcome"]
+    stmt: Stmt
+    opts: Dict[str, object]
+    fact_id: str
+    soft_selectors: Set[str]
+
+
+@dataclass
+class RuleOutcome:
+    candidates: List[Point]
+    notes: List[str]
+    chosen_by: Literal[
+        "unique",
+        "opts",
+        "ray/segment filter",
+        "closest-to-solver",
+        "undetermined",
+    ]
+
+
+class EvalContext:
+    """Point lookup helper used by rule solvers."""
+
+    def __init__(
+        self,
+        coords: Dict[str, Point],
+        base_coords: Dict[str, Point],
+        circle_lookup: Dict[str, CircleInfo],
+    ) -> None:
+        self._coords = coords
+        self._base = base_coords
+        self._circles = circle_lookup
+
+    def has_point(self, name: str) -> bool:
+        return name in self._coords or name in self._base
+
+    def require_point(self, name: str) -> Point:
+        if name in self._coords:
+            return self._coords[name]
+        if name in self._base:
+            return self._base[name]
+        raise KeyError(name)
+
+    def circle_info(self, center: str) -> Optional[CircleInfo]:
+        return self._circles.get(center)
+
+    def all_known(self) -> Set[str]:
+        return set(self._coords) | set(self._base)
+
+
+def _vec(a: Point, b: Point) -> Point:
+    return b[0] - a[0], b[1] - a[1]
+
+
+def _dot(a: Point, b: Point) -> float:
+    return a[0] * b[0] + a[1] * b[1]
+
+
+def _cross(a: Point, b: Point) -> float:
+    return a[0] * b[1] - a[1] * b[0]
+
+
+def _norm_sq(v: Point) -> float:
+    return _dot(v, v)
+
+
+def _norm(v: Point) -> float:
+    return sqrt(max(_norm_sq(v), 0.0))
+
+
+def _normalize(v: Point) -> Optional[Point]:
+    n = _norm(v)
+    if n <= _EPS:
+        return None
+    return v[0] / n, v[1] / n
+
+
+def _rotate90(v: Point) -> Point:
+    return -v[1], v[0]
+
+
+def _distance(a: Point, b: Point) -> float:
+    return _norm(_vec(a, b))
+
+
+def _midpoint(a: Point, b: Point) -> Point:
+    return (a[0] + b[0]) / 2.0, (a[1] + b[1]) / 2.0
+
+
+def _format_edge(edge: Sequence[str]) -> str:
+    if len(edge) != 2:
+        return "?"
+    return f"{edge[0]}-{edge[1]}"
+
+
+def _project_parameter(anchor: Point, direction: Point, point: Point) -> Optional[float]:
+    denom = _dot(direction, direction)
+    if denom <= _EPS:
+        return None
+    return _dot(_vec(anchor, point), direction) / denom
+
+
+def _is_on_segment(param: Optional[float]) -> bool:
+    if param is None:
+        return False
+    return -_MEMBERSHIP_EPS <= param <= 1.0 + _MEMBERSHIP_EPS
+
+
+def _is_on_ray(param: Optional[float]) -> bool:
+    if param is None:
+        return False
+    return param >= -_MEMBERSHIP_EPS
+
+
+def _line_spec_from_path(path: Tuple[str, object], ctx: EvalContext) -> Optional[LineSpec]:
+    kind, payload = path
+    if kind in {"line", "segment", "ray"}:
+        if not isinstance(payload, (list, tuple)) or len(payload) != 2:
+            return None
+        a_name, b_name = payload
+        if not (isinstance(a_name, str) and isinstance(b_name, str)):
+            return None
+        if not (ctx.has_point(a_name) and ctx.has_point(b_name)):
+            return None
+        a = ctx.require_point(a_name)
+        b = ctx.require_point(b_name)
+        direction = _vec(a, b)
+        if _norm_sq(direction) <= _EPS:
+            return None
+        return LineSpec(kind=kind, anchor=a, direction=direction, endpoints=(a_name, b_name))
+    if kind == "perpendicular":
+        if not isinstance(payload, dict):
+            return None
+        at = payload.get("at")
+        to_edge = payload.get("to")
+        if not (isinstance(at, str) and isinstance(to_edge, (list, tuple)) and len(to_edge) == 2):
+            return None
+        a_name, b_name = to_edge
+        if not (isinstance(a_name, str) and isinstance(b_name, str)):
+            return None
+        if not (ctx.has_point(at) and ctx.has_point(a_name) and ctx.has_point(b_name)):
+            return None
+        base = _vec(ctx.require_point(a_name), ctx.require_point(b_name))
+        if _norm_sq(base) <= _EPS:
+            return None
+        return LineSpec(
+            kind="line",
+            anchor=ctx.require_point(at),
+            direction=_rotate90(base),
+            endpoints=(at, at),
+        )
+    if kind == "perp-bisector":
+        if not isinstance(payload, (list, tuple)) or len(payload) != 2:
+            return None
+        a_name, b_name = payload
+        if not (isinstance(a_name, str) and isinstance(b_name, str)):
+            return None
+        if not (ctx.has_point(a_name) and ctx.has_point(b_name)):
+            return None
+        a = ctx.require_point(a_name)
+        b = ctx.require_point(b_name)
+        direction = _vec(a, b)
+        if _norm_sq(direction) <= _EPS:
+            return None
+        return LineSpec(
+            kind="line",
+            anchor=_midpoint(a, b),
+            direction=_rotate90(direction),
+            endpoints=(a_name, b_name),
+        )
+    if kind == "parallel":
+        if not isinstance(payload, dict):
+            return None
+        through = payload.get("through")
+        ref = payload.get("to")
+        if not (
+            isinstance(through, str)
+            and isinstance(ref, (list, tuple))
+            and len(ref) == 2
+            and all(isinstance(x, str) for x in ref)
+        ):
+            return None
+        if not (ctx.has_point(through) and ctx.has_point(ref[0]) and ctx.has_point(ref[1])):
+            return None
+        base_dir = _vec(ctx.require_point(ref[0]), ctx.require_point(ref[1]))
+        if _norm_sq(base_dir) <= _EPS:
+            return None
+        return LineSpec(
+            kind="line",
+            anchor=ctx.require_point(through),
+            direction=base_dir,
+            endpoints=(through, through),
+        )
+    if kind == "median":
+        if not isinstance(payload, dict):
+            return None
+        frm = payload.get("frm")
+        to_edge = payload.get("to")
+        if not (
+            isinstance(frm, str)
+            and isinstance(to_edge, (list, tuple))
+            and len(to_edge) == 2
+            and all(isinstance(x, str) for x in to_edge)
+        ):
+            return None
+        if not (ctx.has_point(frm) and ctx.has_point(to_edge[0]) and ctx.has_point(to_edge[1])):
+            return None
+        mid = _midpoint(ctx.require_point(to_edge[0]), ctx.require_point(to_edge[1]))
+        direction = _vec(ctx.require_point(frm), mid)
+        if _norm_sq(direction) <= _EPS:
+            return None
+        return LineSpec(kind="line", anchor=ctx.require_point(frm), direction=direction, endpoints=(frm, frm))
+    if kind == "angle-bisector":
+        if not isinstance(payload, dict):
+            return None
+        pts = payload.get("points")
+        if not (isinstance(pts, (list, tuple)) and len(pts) == 3 and all(isinstance(x, str) for x in pts)):
+            return None
+        u, v, w = pts
+        if not (ctx.has_point(u) and ctx.has_point(v) and ctx.has_point(w)):
+            return None
+        vu = _vec(ctx.require_point(v), ctx.require_point(u))
+        vw = _vec(ctx.require_point(v), ctx.require_point(w))
+        nu = _normalize(vu)
+        nw = _normalize(vw)
+        if nu is None or nw is None:
+            return None
+        if payload.get("external"):
+            direction = (nu[0] - nw[0], nu[1] - nw[1])
+        else:
+            direction = (nu[0] + nw[0], nu[1] + nw[1])
+        n_dir = _normalize(direction)
+        if n_dir is None:
+            return None
+        return LineSpec(kind="line", anchor=ctx.require_point(v), direction=n_dir, endpoints=(v, v))
+    return None
+
+
+def _circle_spec_from_path(path: Tuple[str, object], ctx: EvalContext) -> Optional[CircleSpec]:
+    kind, payload = path
+    if kind != "circle":
+        return None
+    if not isinstance(payload, str):
+        return None
+    info = ctx.circle_info(payload)
+    if info is None:
+        return None
+    if not (ctx.has_point(info.center) and ctx.has_point(info.through)):
+        return None
+    center = ctx.require_point(info.center)
+    through = ctx.require_point(info.through)
+    radius = _distance(center, through)
+    if radius <= _EPS:
+        return None
+    return CircleSpec(center=center, radius=radius, center_name=info.center, through_name=info.through)
+
+
+def _intersect_lines(a: LineSpec, b: LineSpec) -> List[Point]:
+    ap = a.anchor
+    bp = b.anchor
+    r = a.direction
+    s = b.direction
+    denom = _cross(r, s)
+    if abs(denom) <= _EPS:
+        return []
+    qp = (bp[0] - ap[0], bp[1] - ap[1])
+    t = _cross(qp, s) / denom
+    return [(ap[0] + t * r[0], ap[1] + t * r[1])]
+
+
+def _line_membership(spec: LineSpec, pt: Point) -> bool:
+    param = _project_parameter(spec.anchor, spec.direction, pt)
+    if spec.kind == "line":
+        return param is not None
+    if spec.kind == "ray":
+        return _is_on_ray(param)
+    if spec.kind == "segment":
+        return _is_on_segment(param)
+    return True
+
+
+def _intersect_line_circle(line: LineSpec, circle: CircleSpec) -> List[Point]:
+    p = line.anchor
+    d = line.direction
+    c = circle.center
+    diff = (p[0] - c[0], p[1] - c[1])
+    a = _dot(d, d)
+    b = 2.0 * _dot(d, diff)
+    c_term = _dot(diff, diff) - circle.radius * circle.radius
+    if abs(a) <= _EPS:
+        return []
+    disc = b * b - 4.0 * a * c_term
+    if disc < -_EPS:
+        return []
+    if abs(disc) <= _EPS:
+        t = -b / (2.0 * a)
+        return [(p[0] + t * d[0], p[1] + t * d[1])]
+    sqrt_disc = sqrt(max(disc, 0.0))
+    t1 = (-b - sqrt_disc) / (2.0 * a)
+    t2 = (-b + sqrt_disc) / (2.0 * a)
+    return [
+        (p[0] + t1 * d[0], p[1] + t1 * d[1]),
+        (p[0] + t2 * d[0], p[1] + t2 * d[1]),
+    ]
+
+
+def _intersect_circles(a: CircleSpec, b: CircleSpec) -> List[Point]:
+    c0 = a.center
+    c1 = b.center
+    r0 = a.radius
+    r1 = b.radius
+    dx = c1[0] - c0[0]
+    dy = c1[1] - c0[1]
+    d = sqrt(dx * dx + dy * dy)
+    if d <= _EPS:
+        return []
+    if d > r0 + r1 + _MEMBERSHIP_EPS:
+        return []
+    if d < abs(r0 - r1) - _MEMBERSHIP_EPS:
+        return []
+    a_param = (r0 * r0 - r1 * r1 + d * d) / (2.0 * d)
+    h_sq = r0 * r0 - a_param * a_param
+    if h_sq < -_EPS:
+        return []
+    h = sqrt(max(h_sq, 0.0))
+    x2 = c0[0] + (a_param * dx) / d
+    y2 = c0[1] + (a_param * dy) / d
+    rx = -dy * (h / d)
+    ry = dx * (h / d)
+    if abs(h) <= _EPS:
+        return [(x2, y2)]
+    return [(x2 + rx, y2 + ry), (x2 - rx, y2 - ry)]
+
+
+def _apply_soft_selectors(
+    candidates: List[Point],
+    opts: Dict[str, object],
+    ctx: EvalContext,
+    notes: List[str],
+) -> Tuple[List[Point], bool]:
+    if len(candidates) <= 1:
+        return candidates, False
+    choose = opts.get("choose")
+    if not isinstance(choose, str):
+        return candidates, False
+    choose_lower = choose.lower()
+    filtered = candidates
+    changed = False
+    if choose_lower in {"near", "far"}:
+        anchor = opts.get("anchor")
+        if isinstance(anchor, str) and ctx.has_point(anchor):
+            anchor_pt = ctx.require_point(anchor)
+            distances = [(_distance(anchor_pt, c), idx) for idx, c in enumerate(candidates)]
+            if choose_lower == "near":
+                best = min(distances, key=lambda item: item[0])[1]
+            else:
+                best = max(distances, key=lambda item: item[0])[1]
+            filtered = [candidates[best]]
+            changed = True
+        else:
+            notes.append("soft selector missing anchor")
+    elif choose_lower in {"left", "right"}:
+        ref = opts.get("ref")
+        if isinstance(ref, str) and "-" in ref:
+            start, end = ref.split("-", 1)
+            if ctx.has_point(start) and ctx.has_point(end):
+                start_pt = ctx.require_point(start)
+                dir_vec = _vec(start_pt, ctx.require_point(end))
+                if _norm_sq(dir_vec) > _EPS:
+                    selected: List[Point] = []
+                    for c in candidates:
+                        rel = _vec(start_pt, c)
+                        side = _cross(dir_vec, rel)
+                        if choose_lower == "left" and side >= -_MEMBERSHIP_EPS:
+                            selected.append(c)
+                        if choose_lower == "right" and side <= _MEMBERSHIP_EPS:
+                            selected.append(c)
+                    if selected:
+                        filtered = selected
+                        changed = True
+                else:
+                    notes.append("ref edge degenerate")
+            else:
+                notes.append("soft selector missing ref points")
+        else:
+            notes.append("soft selector requires ref=A-B")
+    elif choose_lower in {"cw", "ccw"}:
+        anchor = opts.get("anchor")
+        ref = opts.get("ref")
+        if isinstance(anchor, str) and ctx.has_point(anchor):
+            anchor_pt = ctx.require_point(anchor)
+            ref_vec = None
+            if isinstance(ref, str) and "-" in ref:
+                start, end = ref.split("-", 1)
+                if ctx.has_point(start) and ctx.has_point(end):
+                    ref_vec = _vec(ctx.require_point(start), ctx.require_point(end))
+            if ref_vec is None:
+                ref_vec = (1.0, 0.0)
+            if _norm_sq(ref_vec) > _EPS:
+                selected: List[Point] = []
+                base_angle = atan2(ref_vec[1], ref_vec[0])
+                for c in candidates:
+                    vec = _vec(anchor_pt, c)
+                    if _norm_sq(vec) <= _EPS:
+                        selected.append(c)
+                        continue
+                    angle = atan2(vec[1], vec[0])
+                    delta = angle - base_angle
+                    while delta <= -3.141592653589793:
+                        delta += 6.283185307179586
+                    while delta > 3.141592653589793:
+                        delta -= 6.283185307179586
+                    if choose_lower == "ccw" and delta >= -_MEMBERSHIP_EPS:
+                        selected.append(c)
+                    if choose_lower == "cw" and delta <= _MEMBERSHIP_EPS:
+                        selected.append(c)
+                if selected:
+                    filtered = selected
+                    changed = True
+            else:
+                notes.append("soft selector ref degenerate")
+        else:
+            notes.append("soft selector missing anchor")
+    return filtered, changed
+
+
+def _apply_membership_filters(candidates: List[Point], specs: Iterable[LineSpec], notes: List[str]) -> Tuple[List[Point], bool]:
+    if not candidates:
+        return candidates, False
+    filtered: List[Point] = []
+    eliminated = False
+    for pt in candidates:
+        ok = True
+        for spec in specs:
+            if not _line_membership(spec, pt):
+                ok = False
+                eliminated = True
+                break
+        if ok:
+            filtered.append(pt)
+    if eliminated:
+        notes.append("ray/segment membership filter applied")
+    return filtered, eliminated
+
+
+def _rule_result(
+    candidates: List[Point],
+    opts: Dict[str, object],
+    ctx: EvalContext,
+    hard_specs: Iterable[LineSpec],
+    notes: List[str],
+) -> RuleOutcome:
+    hard_filtered, hard_changed = _apply_membership_filters(list(candidates), hard_specs, notes)
+    if not hard_filtered:
+        return RuleOutcome(candidates=[], notes=notes, chosen_by="undetermined")
+    soft_filtered, soft_changed = _apply_soft_selectors(hard_filtered, opts, ctx, notes)
+    if not soft_filtered:
+        return RuleOutcome(candidates=[], notes=notes, chosen_by="undetermined")
+    if len(soft_filtered) == 1:
+        if soft_changed:
+            chosen = "opts"
+        elif hard_changed:
+            chosen = "ray/segment filter"
+        else:
+            chosen = "unique"
+    else:
+        chosen = "closest-to-solver"
+    return RuleOutcome(candidates=soft_filtered, notes=notes, chosen_by=chosen)
+
+
+def _make_midpoint_rule(stmt: Stmt) -> Optional[Rule]:
+    midpoint = stmt.data.get("midpoint")
+    edge = stmt.data.get("edge")
+    if not (
+        isinstance(midpoint, str)
+        and isinstance(edge, (list, tuple))
+        and len(edge) == 2
+        and all(isinstance(x, str) for x in edge)
+    ):
+        return None
+
+    inputs = {edge[0], edge[1]}
+
+    def solver(ctx: EvalContext) -> RuleOutcome:
+        a = ctx.require_point(edge[0])
+        b = ctx.require_point(edge[1])
+        cand = [_midpoint(a, b)]
+        return RuleOutcome(candidates=cand, notes=[], chosen_by="unique")
+
+    fact = f"midpoint({midpoint};{_format_edge(edge)})"
+    return Rule(
+        name=f"midpoint {midpoint}",
+        point=midpoint,
+        inputs=inputs,
+        multiplicity=1,
+        solver=solver,
+        stmt=stmt,
+        opts=stmt.opts,
+        fact_id=fact,
+        soft_selectors=set(),
+    )
+
+
+def _make_foot_rule(stmt: Stmt) -> Optional[Rule]:
+    foot_pt = stmt.data.get("foot")
+    src = stmt.data.get("from") or stmt.data.get("at")
+    edge = stmt.data.get("edge") or stmt.data.get("to")
+    if not (
+        isinstance(foot_pt, str)
+        and isinstance(src, str)
+        and isinstance(edge, (list, tuple))
+        and len(edge) == 2
+        and all(isinstance(x, str) for x in edge)
+    ):
+        return None
+
+    inputs = {src, edge[0], edge[1]}
+
+    def solver(ctx: EvalContext) -> RuleOutcome:
+        base_a = ctx.require_point(edge[0])
+        base_b = ctx.require_point(edge[1])
+        vertex = ctx.require_point(src)
+        direction = _vec(base_a, base_b)
+        denom = _dot(direction, direction)
+        notes: List[str] = []
+        if denom <= _EPS:
+            notes.append("base edge degenerate")
+            return RuleOutcome(candidates=[], notes=notes, chosen_by="undetermined")
+        t = _dot(_vec(base_a, vertex), direction) / denom
+        proj = (base_a[0] + t * direction[0], base_a[1] + t * direction[1])
+        return RuleOutcome(candidates=[proj], notes=notes, chosen_by="unique")
+
+    fact = f"foot({foot_pt};{src}->{_format_edge(edge)})"
+    return Rule(
+        name=f"foot {foot_pt}",
+        point=foot_pt,
+        inputs=inputs,
+        multiplicity=1,
+        solver=solver,
+        stmt=stmt,
+        opts=stmt.opts,
+        fact_id=fact,
+        soft_selectors=set(),
+    )
+
+
+def _make_diameter_rules(stmt: Stmt) -> List[Rule]:
+    center = stmt.data.get("center")
+    edge = stmt.data.get("edge")
+    if not (
+        isinstance(center, str)
+        and isinstance(edge, (list, tuple))
+        and len(edge) == 2
+        and all(isinstance(x, str) for x in edge)
+    ):
+        return []
+
+    rules: List[Rule] = []
+
+    def make_rule(known: str, missing: str) -> Rule:
+        inputs = {center, known}
+
+        def solver(ctx: EvalContext) -> RuleOutcome:
+            c = ctx.require_point(center)
+            k = ctx.require_point(known)
+            reflected = (2.0 * c[0] - k[0], 2.0 * c[1] - k[1])
+            return RuleOutcome(candidates=[reflected], notes=[], chosen_by="unique")
+
+        fact = f"diameter({center};{_format_edge(edge)})"
+        return Rule(
+            name=f"diameter {missing}",
+            point=missing,
+            inputs=inputs,
+            multiplicity=1,
+            solver=solver,
+            stmt=stmt,
+            opts=stmt.opts,
+            fact_id=fact,
+            soft_selectors=set(),
+        )
+
+    rules.append(make_rule(edge[0], edge[1]))
+    rules.append(make_rule(edge[1], edge[0]))
+    return rules
+
+
+def _path_dependencies(path: Tuple[str, object], circle_lookup: Dict[str, CircleInfo]) -> Set[str]:
+    kind, payload = path
+    deps: Set[str] = set()
+    if kind in {"line", "segment", "ray", "perp-bisector"}:
+        if isinstance(payload, (list, tuple)):
+            deps.update([pt for pt in payload if isinstance(pt, str)])
+        return deps
+    if kind == "circle":
+        if isinstance(payload, str):
+            info = circle_lookup.get(payload)
+            if info:
+                deps.add(info.center)
+                deps.add(info.through)
+        return deps
+    if kind in {"perpendicular", "median", "parallel"}:
+        if isinstance(payload, dict):
+            for key in ("at", "frm", "through"):
+                val = payload.get(key)
+                if isinstance(val, str):
+                    deps.add(val)
+            ref = payload.get("to")
+            if isinstance(ref, (list, tuple)):
+                deps.update([pt for pt in ref if isinstance(pt, str)])
+        return deps
+    if kind == "angle-bisector":
+        if isinstance(payload, dict):
+            pts = payload.get("points")
+            if isinstance(pts, (list, tuple)):
+                deps.update([pt for pt in pts if isinstance(pt, str)])
+        return deps
+    return deps
+
+
+def _make_intersect_rule(stmt: Stmt, circle_lookup: Dict[str, CircleInfo]) -> List[Rule]:
+    path1 = stmt.data.get("path1")
+    path2 = stmt.data.get("path2")
+    at1 = stmt.data.get("at")
+    at2 = stmt.data.get("at2")
+    if not (isinstance(path1, tuple) and isinstance(path2, tuple)):
+        return []
+
+    results: List[Rule] = []
+
+    def make_rule(point_name: str) -> Optional[Rule]:
+        if not isinstance(point_name, str):
+            return None
+        inputs = _path_dependencies(path1, circle_lookup) | _path_dependencies(path2, circle_lookup)
+
+        def solver(ctx: EvalContext) -> RuleOutcome:
+            notes: List[str] = []
+            hard_specs: List[LineSpec] = []
+            candidates: List[Point] = []
+            p1_line = _line_spec_from_path(path1, ctx)
+            p2_line = _line_spec_from_path(path2, ctx)
+            p1_circle = _circle_spec_from_path(path1, ctx)
+            p2_circle = _circle_spec_from_path(path2, ctx)
+            if p1_line and p2_line:
+                candidates = _intersect_lines(p1_line, p2_line)
+                hard_specs.extend(
+                    [spec for spec in (p1_line, p2_line) if spec.kind in {"segment", "ray"}]
+                )
+            elif p1_line and p2_circle:
+                candidates = _intersect_line_circle(p1_line, p2_circle)
+                hard_specs.extend([spec for spec in (p1_line,) if spec.kind in {"segment", "ray"}])
+            elif p2_line and p1_circle:
+                candidates = _intersect_line_circle(p2_line, p1_circle)
+                hard_specs.extend([spec for spec in (p2_line,) if spec.kind in {"segment", "ray"}])
+            elif p1_circle and p2_circle:
+                candidates = _intersect_circles(p1_circle, p2_circle)
+            else:
+                notes.append("unsupported intersection types")
+                return RuleOutcome(candidates=[], notes=notes, chosen_by="undetermined")
+            return _rule_result(candidates, stmt.opts, ctx, hard_specs, notes)
+
+        fact = f"intersect({point_name})"
+        return Rule(
+            name=f"intersect {point_name}",
+            point=point_name,
+            inputs=inputs,
+            multiplicity=2,
+            solver=solver,
+            stmt=stmt,
+            opts=stmt.opts,
+            fact_id=fact,
+            soft_selectors={key for key in ("choose", "anchor", "ref") if key in stmt.opts},
+        )
+
+    rule1 = make_rule(at1)
+    rule2 = make_rule(at2)
+    if rule1:
+        results.append(rule1)
+    if rule2:
+        results.append(rule2)
+    return results
+
+
+def _collect_circles(program: Program) -> Dict[str, CircleInfo]:
+    circles: Dict[str, CircleInfo] = {}
+    for stmt in program.stmts:
+        if stmt.kind == "circle_center_radius_through":
+            center = stmt.data.get("center")
+            through = stmt.data.get("through")
+            if isinstance(center, str) and isinstance(through, str):
+                circles[center] = CircleInfo(center=center, through=through, stmt=stmt)
+    return circles
+
+
+def _collect_rules(program: Program, circles: Dict[str, CircleInfo]) -> List[Rule]:
+    rules: List[Rule] = []
+    for stmt in program.stmts:
+        if stmt.kind in {"midpoint", "median_from_to"}:
+            rule = _make_midpoint_rule(stmt)
+            if rule:
+                rules.append(rule)
+        elif stmt.kind in {"foot", "perpendicular_at"}:
+            rule = _make_foot_rule(stmt)
+            if rule:
+                rules.append(rule)
+        elif stmt.kind == "diameter":
+            rules.extend(_make_diameter_rules(stmt))
+        elif stmt.kind == "intersect":
+            rules.extend(_make_intersect_rule(stmt, circles))
+    return rules
+
+
+def _topological_sort(points: Set[str], rules: List[Rule]) -> Tuple[List[str], List[Tuple[str, str]]]:
+    edges: List[Tuple[str, str]] = []
+    indegree: Dict[str, int] = {p: 0 for p in points}
+    for rule in rules:
+        for dep in rule.inputs:
+            if dep in indegree:
+                edges.append((dep, rule.point))
+                indegree[rule.point] = indegree.get(rule.point, 0) + 1
+    queue: List[str] = [p for p, deg in indegree.items() if deg == 0]
+    topo: List[str] = []
+    i = 0
+    while i < len(queue):
+        node = queue[i]
+        topo.append(node)
+        for dep, tgt in list(edges):
+            if dep == node:
+                indegree[tgt] -= 1
+                if indegree[tgt] == 0:
+                    queue.append(tgt)
+        i += 1
+    seen = set(topo)
+    for node in points:
+        if node not in seen:
+            topo.append(node)
+    return topo, edges
+
+
+def _compute_scene_scale(solution: Solution, program: Program) -> float:
+    coords = solution.point_coords
+    if coords:
+        xs = [p[0] for p in coords.values()]
+        ys = [p[1] for p in coords.values()]
+        min_x, max_x = min(xs), max(xs)
+        min_y, max_y = min(ys), max(ys)
+        diag = sqrt((max_x - min_x) ** 2 + (max_y - min_y) ** 2)
+        if diag > _EPS:
+            return max(diag, 1.0)
+    for stmt in program.stmts:
+        if stmt.kind == "layout":
+            scale = stmt.data.get("scale")
+            if isinstance(scale, (int, float)):
+                return float(scale)
+    return 1.0
+
+
+def derive_and_check(
+    program: Program,
+    solution: Solution,
+    *,
+    tol: Optional[float] = None,
+) -> DerivationReport:
+    circles = _collect_circles(program)
+    rules = _collect_rules(program, circles)
+    base_coords = dict(solution.point_coords)
+    derived_coords: Dict[str, Point] = {}
+    reports: Dict[str, DerivedPointReport] = {}
+    unused: List[str] = []
+
+    ctx = EvalContext(derived_coords, base_coords, circles)
+
+    remaining_rules = list(rules)
+    progress = True
+    while progress:
+        progress = False
+        for rule in list(remaining_rules):
+            if rule.point in reports:
+                remaining_rules.remove(rule)
+                continue
+            if not all(ctx.has_point(dep) for dep in rule.inputs):
+                continue
+            outcome = rule.solver(ctx)
+            if not outcome.candidates and rule.multiplicity == 1:
+                reports[rule.point] = DerivedPointReport(
+                    rule=rule.fact_id,
+                    inputs=sorted(rule.inputs),
+                    candidates=[],
+                    chosen_by="undetermined",
+                    match="no",
+                    dist=float("inf"),
+                    notes=list(outcome.notes) + ["no candidates"],
+                )
+            else:
+                reports[rule.point] = DerivedPointReport(
+                    rule=rule.fact_id,
+                    inputs=sorted(rule.inputs),
+                    candidates=list(outcome.candidates),
+                    chosen_by=outcome.chosen_by,
+                    notes=list(outcome.notes),
+                )
+                if len(outcome.candidates) == 1:
+                    derived_coords[rule.point] = outcome.candidates[0]
+            remaining_rules.remove(rule)
+            progress = True
+    for rule in remaining_rules:
+        unused.append(rule.fact_id)
+
+    tol_value = tol if tol is not None else 1e-6 * _compute_scene_scale(solution, program)
+
+    mismatches = 0
+    ambiguous = 0
+    partial = 0
+    matched = 0
+
+    for point, report in reports.items():
+        candidates = report.get("candidates", []) or []
+        solver_coord = solution.point_coords.get(point)
+        if not candidates:
+            report["match"] = "no"
+            report["dist"] = float("inf")
+            partial += 1
+            continue
+        if solver_coord is None:
+            report["match"] = "no"
+            report["dist"] = float("inf")
+            mismatches += 1
+            continue
+        dist = min(_distance(c, solver_coord) for c in candidates)
+        report["dist"] = dist
+        if dist <= tol_value:
+            report["match"] = "yes"
+            matched += 1
+            if len(candidates) > 1:
+                ambiguous += 1
+        else:
+            report["match"] = "no"
+            mismatches += 1
+
+    status: Literal["ok", "mismatch", "ambiguous", "partial"]
+    if mismatches:
+        status = "mismatch"
+    elif partial:
+        status = "partial"
+    elif ambiguous:
+        status = "ambiguous"
+    else:
+        status = "ok"
+
+    summary = (
+        f"Derived {len(reports)} point(s) — {matched} matched, {mismatches} mismatched, "
+        f"{partial} not derivable, {ambiguous} ambiguous"
+    )
+
+    graph_points: Set[str] = set(base_coords)
+    for rule in rules:
+        graph_points.add(rule.point)
+        graph_points.update(rule.inputs)
+    topo_order, edges = _topological_sort(graph_points, rules)
+
+    return DerivationReport(
+        status=status,
+        summary=summary,
+        points=reports,
+        unused_facts=sorted(unused),
+        graph=DerivationGraphExport(
+            nodes=sorted(graph_points),
+            edges=edges,
+            topo_order=topo_order,
+        ),
+    )

--- a/tests/test_ddc.py
+++ b/tests/test_ddc.py
@@ -1,0 +1,84 @@
+import math
+
+from geoscript_ir.ast import Program, Span, Stmt
+from geoscript_ir.ddc import derive_and_check
+from geoscript_ir.solver import Solution
+
+
+def build_program() -> Program:
+    span = Span(1, 1)
+    return Program(
+        [
+            Stmt("segment", span, {"edge": ("A", "B")}, origin="source"),
+            Stmt("midpoint", span, {"midpoint": "M", "edge": ("A", "B")}, origin="source"),
+            Stmt("foot", span, {"foot": "H", "from": "C", "edge": ("A", "B")}, origin="source"),
+            Stmt(
+                "circle_center_radius_through",
+                span,
+                {"center": "O", "through": "P"},
+                origin="source",
+            ),
+            Stmt("line", span, {"edge": ("X", "Y")}, origin="source"),
+            Stmt(
+                "intersect",
+                span,
+                {
+                    "path1": ("line", ("X", "Y")),
+                    "path2": ("circle", "O"),
+                    "at": "D",
+                    "at2": None,
+                },
+                origin="source",
+            ),
+        ]
+    )
+
+
+def build_solution() -> Solution:
+    coords = {
+        "A": (0.0, 0.0),
+        "B": (4.0, 0.0),
+        "C": (1.0, 3.0),
+        "M": (2.0, 0.0),
+        "H": (1.0, 0.0),
+        "O": (0.0, 0.0),
+        "P": (5.0, 0.0),
+        "X": (3.0, 4.0),
+        "Y": (3.0, -4.0),
+        "D": (3.0, 4.0),
+    }
+    return Solution(
+        point_coords=coords,
+        success=True,
+        max_residual=0.0,
+        residual_breakdown=[],
+        warnings=[],
+    )
+
+
+def test_ddc_derives_midpoint_and_foot_and_detects_ambiguity():
+    program = build_program()
+    solution = build_solution()
+
+    report = derive_and_check(program, solution)
+
+    assert report["status"] == "ambiguous"
+    assert report["unused_facts"] == []
+
+    midpoint = report["points"].get("M")
+    assert midpoint is not None
+    assert midpoint["match"] == "yes"
+    assert midpoint["chosen_by"] == "unique"
+    assert math.isclose(midpoint["dist"], 0.0, abs_tol=1e-9)
+
+    foot = report["points"].get("H")
+    assert foot is not None
+    assert foot["match"] == "yes"
+    assert foot["chosen_by"] == "unique"
+
+    intersection = report["points"].get("D")
+    assert intersection is not None
+    assert intersection["match"] == "yes"
+    assert intersection["chosen_by"] == "closest-to-solver"
+    assert len(intersection["candidates"]) == 2
+    assert any(abs(pt[1] - 4.0) < 1e-9 for pt in intersection["candidates"])


### PR DESCRIPTION
## Summary
- add a deterministic derivation & cross-check module that evaluates geometric rules and compares against solver output
- expose the new derive_and_check entry point via the package __init__
- add coverage that exercises midpoint, foot, and ambiguous intersection derivations

## Testing
- pytest tests/test_ddc.py

------
https://chatgpt.com/codex/tasks/task_e_68e3c079b3d8832780958cff210690f7