### PR TITLE
Implement derivation plan workflow and solver integration

### DIFF
--- a/geoscript_ir/__init__.py
+++ b/geoscript_ir/__init__.py
@@ -9,6 +9,8 @@ from .reference_tikz import GEOSCRIPT_TO_TIKZ_PROMPT
 from .tikz_codegen import generate_tikz_code, generate_tikz_document, latex_escape_keep_math
 from .solver import (
     translate,
+    plan_derive,
+    compile_with_plan,
     solve,
     solve_best_model,
     solve_with_desugar_variants,
@@ -32,6 +34,8 @@ __all__ = [
     'print_program',
     'format_stmt',
     'translate',
+    'plan_derive',
+    'compile_with_plan',
     'solve',
     'solve_best_model',
     'solve_with_desugar_variants',


### PR DESCRIPTION
## Summary
- add derivation-planning infrastructure (plan_derive/compile_with_plan) and store plan metadata on the solver model
- update solver evaluation to compute derived coordinates via the plan, handle guard degradation, and surface plan exports
- expose the new APIs and cover them with unit tests for midpoint/altitude derivations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3fa5eace88327ae63548d3525bdad