### PR TITLE
Improve solver stability and update references

### DIFF
--- a/docs/bnf.txt
+++ b/docs/bnf.txt
@@ -1,3 +1,4 @@
+```
 Program   := { Stmt }
 Stmt      := Scene | Layout | Points | Obj | Placement | Annot | Target | Rules | Comment
 
@@ -81,3 +82,4 @@ KeyVal    := KEY '=' (NUMBER | STRING | BOOLEAN | ID | ID '-' ID | SQRT | PRODUC
 SQRT      := 'sqrt' '(' NUMBER ')'
 PRODUCT   := NUMBER '*' SQRT
 BOOLEAN   := 'true' | 'false'
+```

--- a/geoscript_ir/reference.py
+++ b/geoscript_ir/reference.py
@@ -110,6 +110,7 @@ Write **GeoScript IR** programs that the downstream toolchain will parse, valida
 ## Output format (always)
 
 * Start with:
+  * Wrap the entire program between `<geoscript>` and `</geoscript>` tags (no content outside the tags).
 
   1. `scene "Title"`
   2. `layout canonical=<id> scale=<number>`


### PR DESCRIPTION
## Summary
- enhance the solver by keeping metadata for intersection rules, tolerating benign guard failures, and improving initial seeds
- ensure intersection-derived points aren’t promoted when the intersection collapses to an endpoint and compare equal angles by magnitude
- refresh the reference prompt/BNF documentation, including explicit `<geoscript>` wrapping guidance

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e415d64aec8327a8bb0ce8a6813da5