### PR TITLE
Align renderer with spec 19.13 derived marks

### DIFF
--- a/geoscript_ir/tikz_codegen/generator.py
+++ b/geoscript_ir/tikz_codegen/generator.py
@@ -64,12 +64,12 @@ standalone_tpl = r"""\documentclass[border=2pt]{standalone}
   tick1/.style={postaction=decorate, decoration={markings,
       mark=at position 0.5 with {\draw (0,-\gsTick/2) -- (0,\gsTick/2);}}},
   tick2/.style={postaction=decorate, decoration={markings,
-      mark=at position 0.4 with {\draw (0,-\gsTick/2) -- (0,\gsTick/2);},
-      mark=at position 0.6 with {\draw (0,-\gsTick/2) -- (0,\gsTick/2);}}},
+      mark=at position 0.47 with {\draw (0,-\gsTick/2) -- (0,\gsTick/2);},
+      mark=at position 0.53 with {\draw (0,-\gsTick/2) -- (0,\gsTick/2);}}},
   tick3/.style={postaction=decorate, decoration={markings,
-      mark=at position 0.35 with {\draw (0,-\gsTick/2) -- (0,\gsTick/2);},
+      mark=at position 0.44 with {\draw (0,-\gsTick/2) -- (0,\gsTick/2);},
       mark=at position 0.5  with {\draw (0,-\gsTick/2) -- (0,\gsTick/2);},
-      mark=at position 0.65 with {\draw (0,-\gsTick/2) -- (0,\gsTick/2);}}},
+      mark=at position 0.56 with {\draw (0,-\gsTick/2) -- (0,\gsTick/2);}}},
 }
 %% optional layers
 \pgfdeclarelayer{bg}\pgfdeclarelayer{fg}\pgfsetlayers{bg,main,fg}

--- a/geoscript_ir/tikz_codegen/generator.py
+++ b/geoscript_ir/tikz_codegen/generator.py
@@ -62,14 +62,14 @@ standalone_tpl = r"""\documentclass[border=2pt]{standalone}
   circle/.style={line width=\gsLW},
   aux/.style={line width=\gsLWaux, dash pattern=on 3pt off 2pt},
   tick1/.style={postaction=decorate, decoration={markings,
-      mark=at position 0.5 with {\draw (-\gsTick/2,0)--(\gsTick/2,0);}}},
+      mark=at position 0.5 with {\draw (0,-\gsTick/2) -- (0,\gsTick/2);}}},
   tick2/.style={postaction=decorate, decoration={markings,
-      mark=at position 0.4 with {\draw (-\gsTick/2,0)--(\gsTick/2,0);},
-      mark=at position 0.6 with {\draw (-\gsTick/2,0)--(\gsTick/2,0);}}},
+      mark=at position 0.4 with {\draw (0,-\gsTick/2) -- (0,\gsTick/2);},
+      mark=at position 0.6 with {\draw (0,-\gsTick/2) -- (0,\gsTick/2);}}},
   tick3/.style={postaction=decorate, decoration={markings,
-      mark=at position 0.35 with {\draw (-\gsTick/2,0)--(\gsTick/2,0);},
-      mark=at position 0.5  with {\draw (-\gsTick/2,0)--(\gsTick/2,0);},
-      mark=at position 0.65 with {\draw (-\gsTick/2,0)--(\gsTick/2,0);}}},
+      mark=at position 0.35 with {\draw (0,-\gsTick/2) -- (0,\gsTick/2);},
+      mark=at position 0.5  with {\draw (0,-\gsTick/2) -- (0,\gsTick/2);},
+      mark=at position 0.65 with {\draw (0,-\gsTick/2) -- (0,\gsTick/2);}}},
 }
 %% optional layers
 \pgfdeclarelayer{bg}\pgfdeclarelayer{fg}\pgfsetlayers{bg,main,fg}

--- a/main.md
+++ b/main.md
@@ -1290,14 +1290,14 @@ Add seeding tests to the integration flow (see §17):
   circle/.style={line width=\gsLW},
   aux/.style={line width=\gsLWaux, dash pattern=on 3pt off 2pt},
   tick1/.style={postaction=decorate, decoration={markings,
-      mark=at position 0.5 with {\draw (-\gsTick/2,0)--(\gsTick/2,0);}}},
+      mark=at position 0.5 with {\draw (0,-\gsTick/2) -- (0,\gsTick/2);}}},
   tick2/.style={postaction=decorate, decoration={markings,
-      mark=at position 0.4 with {\draw (-\gsTick/2,0)--(\gsTick/2,0);},
-      mark=at position 0.6 with {\draw (-\gsTick/2,0)--(\gsTick/2,0);}}},
+      mark=at position 0.4 with {\draw (0,-\gsTick/2) -- (0,\gsTick/2);},
+      mark=at position 0.6 with {\draw (0,-\gsTick/2) -- (0,\gsTick/2);}}},
   tick3/.style={postaction=decorate, decoration={markings,
-      mark=at position 0.35 with {\draw (-\gsTick/2,0)--(\gsTick/2,0);},
-      mark=at position 0.5  with {\draw (-\gsTick/2,0)--(\gsTick/2,0);},
-      mark=at position 0.65 with {\draw (-\gsTick/2,0)--(\gsTick/2,0);}}},
+      mark=at position 0.35 with {\draw (0,-\gsTick/2) -- (0,\gsTick/2);},
+      mark=at position 0.5  with {\draw (0,-\gsTick/2) -- (0,\gsTick/2);},
+      mark=at position 0.65 with {\draw (0,-\gsTick/2) -- (0,\gsTick/2);}}},
 }
 % optional layers
 \pgfdeclarelayer{bg}\pgfdeclarelayer{fg}\pgfsetlayers{bg,main,fg}
@@ -1763,6 +1763,8 @@ The renderer builds **disjoint groups** for both segments and angles before emis
   * If the segment is already drawn as a **carrier** (polygon side or declared `segment`), attach the tick style to that path.
   * If it is **not otherwise drawn**, render a thin **dashed stub** of the segment solely to host the ticks (do **not** introduce new visible construction lines).
 * **Zero/near‑zero length edges** (`‖AB‖ ≤ ε_len`, §19.12.2): skip ticks.
+
+> **Tick orientation.** Each `tick*` style draws **perpendicular strokes** (local y-axis in the mark frame) so the dash is visible across the carrier instead of hiding along it.
 
 **Precedence when a segment is both explicit and implicit (median/midpoint):**
 Explicit `equal-segments` **wins** (its group_index/ticks are used). Implicit marks are suppressed to avoid double‑marking.

--- a/main.md
+++ b/main.md
@@ -1292,12 +1292,12 @@ Add seeding tests to the integration flow (see §17):
   tick1/.style={postaction=decorate, decoration={markings,
       mark=at position 0.5 with {\draw (0,-\gsTick/2) -- (0,\gsTick/2);}}},
   tick2/.style={postaction=decorate, decoration={markings,
-      mark=at position 0.4 with {\draw (0,-\gsTick/2) -- (0,\gsTick/2);},
-      mark=at position 0.6 with {\draw (0,-\gsTick/2) -- (0,\gsTick/2);}}},
+      mark=at position 0.47 with {\draw (0,-\gsTick/2) -- (0,\gsTick/2);},
+      mark=at position 0.53 with {\draw (0,-\gsTick/2) -- (0,\gsTick/2);}}},
   tick3/.style={postaction=decorate, decoration={markings,
-      mark=at position 0.35 with {\draw (0,-\gsTick/2) -- (0,\gsTick/2);},
+      mark=at position 0.44 with {\draw (0,-\gsTick/2) -- (0,\gsTick/2);},
       mark=at position 0.5  with {\draw (0,-\gsTick/2) -- (0,\gsTick/2);},
-      mark=at position 0.65 with {\draw (0,-\gsTick/2) -- (0,\gsTick/2);}}},
+      mark=at position 0.56 with {\draw (0,-\gsTick/2) -- (0,\gsTick/2);}}},
 }
 % optional layers
 \pgfdeclarelayer{bg}\pgfdeclarelayer{fg}\pgfsetlayers{bg,main,fg}

--- a/main.md
+++ b/main.md
@@ -1711,6 +1711,8 @@ Marks are emitted on the **visible stroke**; no auxiliary carriers are auto‑dr
 * `angle-bisector U-V-W` (path) → **double‑arc** at `V` (equal‑angle mark).
 * `median from P to A-B midpoint M` → **equal‑length** ticks on `A–M` and `M–B`.
 * `midpoint M of A-B` → **equal‑length** ticks on `A–M` and `M–B`.
+* `point M on segment A-B [mark=midpoint]` → same midpoint tick pair on `A–M` and `M–B`.
+* `triangle U-V-W [isosceles=atV]` → **equal‑length** ticks on the two **legs incident to `V`**.
 
 > These implicit visuals are **marks only**. They do not add metric constraints (solver behavior is defined in §6); they exist to make standard constructions legible.
 
@@ -1726,7 +1728,8 @@ The renderer builds **disjoint groups** for both segments and angles before emis
 2. Build a **union‑find (disjoint‑set)** structure:
 
    * For each `equal-segments (E... ; F...)`, **union** all edges in `E∪F`.
-   * For each `midpoint M of A-B` or `median ... midpoint M`, **union** `A–M` with `M–B` into an **implicit** group (unless either edge already belongs to an explicit group; see precedence below).
+   * For each `midpoint M of A-B`, `point M on segment A-B [mark=midpoint]`, or `median ... midpoint M`, **union** `A–M` with `M–B` into an **implicit** group (unless either edge already belongs to an explicit group; see precedence below).
+   * For each `triangle U-V-W [isosceles=atV]`, **union** the two **legs adjacent to `V`** into an implicit group (suppressed if either leg is already explicit).
 3. Compute the **connected components**; each becomes one **segment equality group**.
 4. **Ordering (stable):**
 
@@ -1819,7 +1822,7 @@ class RenderPlan:
     notes: List[str]                             # renderer diagnostics (conflicts, suppressed implicit, g>3 overlays)
 ```
 
-* Populate `ticks` from **explicit** groups first, then add **implicit** pairs `(A,M)` and `(M,B)` from **midpoints/medians** that do **not** collide with explicit groups.
+* Populate `ticks` from **explicit** groups first, then add **implicit** pairs `(A,M)` and `(M,B)` from **midpoints/medians/point-on midpoint marks**, plus the **isosceles legs** `(V,U)` and `(V,W)` that do **not** collide with explicit groups.
 * Populate `equal_angle_groups` from explicit `equal-angles`; add **implicit** “bisector doubles” as single‑vertex marks (no need to enumerate two half‑wedges).
 * Populate `right_angles` from explicit `right-angle` and from **altitude** footprints.
 

--- a/tests/test_tikz_codegen.py
+++ b/tests/test_tikz_codegen.py
@@ -148,6 +148,44 @@ def test_midpoint_adds_equal_length_ticks() -> None:
     assert "\\draw[aux, tick1]" in tikz
 
 
+def test_point_on_segment_midpoint_mark_adds_ticks() -> None:
+    program = Program(
+        [
+            Stmt(
+                "point_on",
+                Span(1, 1),
+                {"point": "M", "path": ("segment", ("A", "B"))},
+                {"mark": "midpoint"},
+            ),
+        ]
+    )
+    coords = {"A": (0.0, 0.0), "B": (2.0, 0.0), "M": (1.0, 0.0)}
+
+    tikz = generate_tikz_code(program, coords)
+
+    assert "\\draw[aux, tick1] (A) -- (M);" in tikz
+    assert "\\draw[aux, tick1] (M) -- (B);" in tikz
+
+
+def test_isosceles_triangle_adds_ticks_on_legs() -> None:
+    program = Program(
+        [
+            Stmt(
+                "triangle",
+                Span(1, 1),
+                {"ids": ["A", "B", "C"]},
+                {"isosceles": "atB"},
+            ),
+        ]
+    )
+    coords = {"A": (0.0, 0.0), "B": (1.0, 1.5), "C": (2.0, 0.0)}
+
+    tikz = generate_tikz_code(program, coords)
+
+    assert "\\draw[carrier, tick1] (A) -- (B);" in tikz
+    assert "\\draw[carrier, tick1] (B) -- (C);" in tikz
+
+
 def test_equal_segments_overflow_uses_overlay_path() -> None:
     program = Program(
         [

--- a/tests/test_tikz_codegen.py
+++ b/tests/test_tikz_codegen.py
@@ -135,3 +135,98 @@ def test_latex_escape_preserves_math_segments() -> None:
     assert "of base" in escaped
 
 
+def test_midpoint_adds_equal_length_ticks() -> None:
+    program = Program(
+        [
+            Stmt("midpoint", Span(1, 1), {"midpoint": "M", "edge": ("A", "B")}),
+        ]
+    )
+    coords = {"A": (0.0, 0.0), "B": (2.0, 0.0), "M": (1.0, 0.0)}
+
+    tikz = generate_tikz_code(program, coords)
+
+    assert "\\draw[aux, tick1]" in tikz
+
+
+def test_equal_segments_overflow_uses_overlay_path() -> None:
+    program = Program(
+        [
+            Stmt("segment", Span(1, 1), {"edge": ("A", "B")}),
+            Stmt("segment", Span(2, 1), {"edge": ("C", "D")}),
+            Stmt("segment", Span(3, 1), {"edge": ("E", "F")}),
+            Stmt("segment", Span(4, 1), {"edge": ("G", "H")}),
+            Stmt("segment", Span(5, 1), {"edge": ("I", "J")}),
+            Stmt("segment", Span(6, 1), {"edge": ("K", "L")}),
+            Stmt("segment", Span(7, 1), {"edge": ("M", "N")}),
+            Stmt("segment", Span(8, 1), {"edge": ("P", "Q")}),
+            Stmt("equal_segments", Span(1, 1), {"lhs": [("A", "B")], "rhs": [("C", "D")]}),
+            Stmt("equal_segments", Span(2, 1), {"lhs": [("E", "F")], "rhs": [("G", "H")]}),
+            Stmt("equal_segments", Span(3, 1), {"lhs": [("I", "J")], "rhs": [("K", "L")]}),
+            Stmt("equal_segments", Span(4, 1), {"lhs": [("M", "N")], "rhs": [("P", "Q")]}),
+        ]
+    )
+    coords = {
+        "A": (0.0, 0.0),
+        "B": (1.0, 0.0),
+        "C": (0.0, 1.0),
+        "D": (1.0, 1.0),
+        "E": (0.0, 2.0),
+        "F": (1.0, 2.0),
+        "G": (0.0, 3.0),
+        "H": (1.0, 3.0),
+        "I": (0.0, 4.0),
+        "J": (1.0, 4.0),
+        "K": (0.0, 5.0),
+        "L": (1.0, 5.0),
+        "M": (0.0, 6.0),
+        "N": (1.0, 6.0),
+        "P": (0.0, 7.0),
+        "Q": (1.0, 7.0),
+    }
+
+    tikz = generate_tikz_code(program, coords)
+
+    assert "draw opacity=0" in tikz
+    assert "carrier, densely dashed" not in tikz
+
+
+def test_angle_bisector_draws_double_arc() -> None:
+    program = Program(
+        [
+            Stmt(
+                "intersect",
+                Span(1, 1),
+                {
+                    "path1": ("angle-bisector", {"points": ("A", "C", "B")}),
+                    "path2": ("segment", ("A", "B")),
+                    "at": "D",
+                    "at2": None,
+                },
+            )
+        ]
+    )
+    coords = {"A": (0.0, 0.0), "B": (2.0, 0.0), "C": (0.5, 1.5), "D": (0.0, 0.0)}
+
+    tikz = generate_tikz_code(program, coords)
+
+    assert tikz.count("angle radius=") == 2
+
+
+def test_foot_adds_right_angle_square_without_rule() -> None:
+    program = Program(
+        [
+            Stmt("foot", Span(1, 1), {"foot": "H", "from": "C", "edge": ("A", "B")}),
+        ]
+    )
+    coords = {
+        "A": (0.0, 0.0),
+        "B": (2.0, 0.0),
+        "C": (0.5, 2.0),
+        "H": (0.5, 0.0),
+    }
+
+    tikz = generate_tikz_code(program, coords)
+
+    assert "right angle=A--H--C" in tikz or "right angle=C--H--A" in tikz
+
+


### PR DESCRIPTION
## Summary
- implement union-find grouping for equal segments/angles and derived marks from midpoints, medians, bisectors, and altitude feet in the TikZ render plan
- add overflow tick overlays, epsilon-based tick filtering, and right-angle handling consistent with the new spec
- extend TikZ tests to cover midpoint ticks, overflow overlays, bisector double arcs, and altitude squares

## Testing
- pip install -e ".[test]"
- pytest tests/test_tikz_codegen.py


------
https://chatgpt.com/codex/tasks/task_e_68e5634c693083278dc029275db38291