### PR TITLE
Remove mark_right_angles_as_square and no_unicode_degree rules

### DIFF
--- a/geoscript_ir/reference.py
+++ b/geoscript_ir/reference.py
@@ -230,7 +230,7 @@ This reduces variables → cleaner, faster solves and less plot jitter.
 
   * `label point P [label="P" pos=above]`
   * `sidelabel A-B "5" [pos=below]`
-* Right angles: `right-angle A-B-C [mark=square]` (or set `rules [mark_right_angles_as_square=true]`).
+* Right angles: `right-angle A-B-C [mark=square]`.
 * Avoid clutter: don’t label every side; prefer key ones.
 * Keep segments from collapsing: choose canonicals that don’t create near-parallel duplicates; if needed, add a simple `segment` or `equal-segments` to stabilize shape.
 

--- a/geoscript_ir/reference_tikz.py
+++ b/geoscript_ir/reference_tikz.py
@@ -26,8 +26,7 @@ GEOSCRIPT_TO_TIKZ_PROMPT = dedent(
       * Annotations: `label point ...`, `sidelabel ...` and their option payloads.
       * Targets: `target angle ...`, `target length ...`, `target point ...`, `target circle (...)`,
         `target area (...)`, `target arc ...`.
-      * Renderer rules in `rules [...]` control styling hints (e.g. `no_unicode_degree`,
-        `mark_right_angles_as_square`).
+      * Renderer rules in `rules [...]` control styling hints (e.g. `no_equations_on_sides`).
 
     OUTPUT CONTRACT
     - Respond with TikZ wrapped exactly once in `<tikz>` and `</tikz>`.
@@ -98,7 +97,7 @@ GEOSCRIPT_TO_TIKZ_PROMPT = dedent(
     - `equal-segments`: apply tick or double-tick styles consistently across each group.
     - `angle A-B-C` and `right-angle A-B-C`: render with `\draw pic{angle = ...}` or
       `\draw pic{right angle = ...}`. If an explicit degree measure appears in options, show it as
-      math text (e.g. `"$30^{\circ}$"`). Obey rule toggles such as `mark_right_angles_as_square`.
+      math text (e.g. `"$30^{\circ}$"`). Mark right angles with squares.
 
     ANNOTATIONS & LABELS
     - `label point P [pos=...] [label="text"]`: attach the label according to the direction hint
@@ -108,7 +107,7 @@ GEOSCRIPT_TO_TIKZ_PROMPT = dedent(
     - `sidelabel A-B "text" [pos=...]`: place the text at the segment midpoint. Always wrap
       sidelabel text in math mode (`{ $<text>$ }`). Do not insert '=' inside the text unless GeoScript
       explicitly requests it.
-    - Respect rules such as `no_unicode_degree=true`; always emit `^\circ` inside math mode.
+    - Always emit `^\circ` inside math mode for degree measurements.
 
     TARGET HIGHLIGHTS
     - `target angle`: draw a dashed pic arc with a "?" or supplied `label=` inside the wedge.
@@ -194,7 +193,6 @@ GEOSCRIPT_TO_TIKZ_PROMPT = dedent(
     line A-C tangent to circle center O at C
     point T on circle center O
     target arc B-T on circle center O [label="?BT"]
-    rules [no_unicode_degree=true mark_right_angles_as_square=true]
     </geoscript>
 
     TikZ (schematic excerpt):

--- a/geoscript_ir/validate.py
+++ b/geoscript_ir/validate.py
@@ -105,7 +105,7 @@ def validate(prog: Program) -> None:
                 raise ValidationError(f'[line {s.span.line}, col {s.span.col}] circle through needs >=3 distinct points')
         elif k == 'rules':
             for key, val in s.opts.items():
-                if key not in ('no_unicode_degree','mark_right_angles_as_square','no_equations_on_sides','no_solving','allow_auxiliary'):
+                if key not in ('no_equations_on_sides','no_solving','allow_auxiliary'):
                     raise ValidationError(f'[line {s.span.line}, col {s.span.col}] unknown rules option "{key}"')
                 if not isinstance(val, bool):
                     raise ValidationError(f'[line {s.span.line}, col {s.span.col}] rules option "{key}" must be boolean')

--- a/main.md
+++ b/main.md
@@ -122,7 +122,7 @@ Only the keys below are interpreted. The parser rejects malformed option syntax;
 
 ### Global
 
-* `rules [...]` → `no_unicode_degree`, `no_equations_on_sides`, `no_solving`, `allow_auxiliary` (booleans).
+* `rules [...]` → `no_equations_on_sides`, `no_solving`, `allow_auxiliary` (booleans).
 
 ### Branch selection (for **Placement**: `point ... on ...`, `intersect(...) ... at ...`)
 
@@ -1266,7 +1266,7 @@ Add seeding tests to the integration flow (see §17):
 * **Visual clarity** with minimal ink: only draw declared carriers and essential construction lines.
 * **Notation completeness**: equal‑segments ticks, equal‑angles arcs, and right‑angle squares are standardized.
 * **Predictable layering** so labels/marks are legible.
-* **Rule‑aware** rendering: respect `rules[...]` flags (`no_equations_on_sides`, `no_unicode_degree`, etc.).
+* **Rule‑aware** rendering: respect `rules[...]` flags (`no_equations_on_sides`, `allow_auxiliary`, etc.).
 
 ---
 
@@ -1337,7 +1337,7 @@ Add seeding tests to the integration flow (see §17):
   \path pic[draw, angle radius=\gsAngR, "$\num{θ}$"{scale=0.9}] {angle=A--B--C};
   ```
 
-  Respect `rules[no_unicode_degree]` by always using `^\circ`. When no `degrees=` metadata exists, pick the ordering whose counter-clockwise sweep is < `180^\circ` (or closest to it if the configuration is straight/reflex) so TikZ draws the minor arc.
+  Always use `^\circ`. When no `degrees=` metadata exists, pick the ordering whose counter-clockwise sweep is < `180^\circ` (or closest to it if the configuration is straight/reflex) so TikZ draws the minor arc.
   Any symbolic `degrees=` metadata first runs through the same math normalisation (`sqrt(...)` → `\sqrt{...}`) before the degree token is appended, ensuring radicals and products render correctly inside the angle label.
 * **Right angle** (`right-angle A-B-C`): always draw the square symbol at `B` via the TikZ `right angle` pic, never an arc or `$90^\circ$` label:
 
@@ -1409,13 +1409,12 @@ Populate this by walking the **desugared** program + options:
 * **Right-angle squares**: use TikZ `pic` right‑angle symbol.
 * **Equal‑angles**: for group *g*, draw `g` arcs at radius `\gsAngR + (k-1)\gsAngSep` (`k=1..g`) with no labels.
 * **Ticks**: apply `tick{g}` style to the **segment** draw command; if the segment is not otherwise drawn (e.g., it’s only an abstract equality), draw the segment **thin dashed** only for the tick mark, or place two small ticks floating near endpoints (simpler: lightly draw the segment).
-* **Angle labels**: always `$\,^\circ$` (LaTeX degree), respecting `no_unicode_degree`.
+* **Angle labels**: always `$\,^\circ$` (LaTeX degree).
 * *(Targets currently produce no additional drawing commands.)*
 
 **19.11.4 Rules mapping**
 
 * `rules[no_equations_on_sides]` → drop numeric edge labels unless created by explicit `sidelabel`.
-* `rules[no_unicode_degree]` → no Unicode “°”; always `^\circ`.
 * `rules[allow_auxiliary]` → if `false`, don’t draw bisector/median/altitude carriers unless explicitly declared as `segment/line/ray`; draw only marks.
 
 **19.11.5 Minimal preamble**
@@ -1930,7 +1929,7 @@ This appendix extends §19 (Rendering Contract) with **deterministic, collision-
 * **Only render what’s declared.** Numeric angles are drawn **only** when the program has `angle A-B-C [degrees=…]` or `target angle …`. Do **not** infer the third triangle angle.
 * **No duplicates.** A segment appears at most once (carrier or aux). Ticks/marks are drawn **once**, on the visible stroke.
 * **Right angle**: draw a square; never print `90^\circ`.
-* **Degree symbol**: always use `^\circ` (respects `no_unicode_degree` and avoids Unicode).
+* **Degree symbol**: always use `^\circ` to avoid Unicode.
 
 ---
 

--- a/tests/integrational/gir/circle_triangle.gir
+++ b/tests/integrational/gir/circle_triangle.gir
@@ -2,7 +2,7 @@
 scene "Diametr MK, MP = PK; find angle POM"
 layout canonical=generic scale=1
 points M, K, O, P
-rules [no_solving=true allow_auxiliary=false no_unicode_degree=true mark_right_angles_as_square=true no_equations_on_sides=true]
+rules [no_solving=true allow_auxiliary=false no_equations_on_sides=true]
 # Окружность с центром O; M на окружности
 circle center O radius-through M
 # Точки K и P на этой окружности

--- a/tests/integrational/gir/triangle_isosceles.gir
+++ b/tests/integrational/gir/triangle_isosceles.gir
@@ -2,7 +2,7 @@
 scene "Isosceles triangle ABC with base AC; AD is angle bisector; find angle ADC; given angle C=50^\\circ"
 layout canonical=triangle_ABC scale=1
 points A, B, C, D
-rules [no_solving=true allow_auxiliary=false no_unicode_degree=true mark_right_angles_as_square=true no_equations_on_sides=true]
+rules [no_solving=true allow_auxiliary=false no_equations_on_sides=true]
 
 # Isosceles with base AC → equal sides AB and BC
 triangle A-B-C [isosceles=atB]

--- a/tests/integrational/gir/triangle_points.gir
+++ b/tests/integrational/gir/triangle_points.gir
@@ -2,7 +2,7 @@
 scene "Triangle with given angles; points D,E on AC; BD=DA, BE=EC; find angle DBE"
 layout canonical=triangle_ABC scale=1
 points A, B, C, D, E
-rules [no_solving=true allow_auxiliary=false no_unicode_degree=true mark_right_angles_as_square=true no_equations_on_sides=true]
+rules [no_solving=true allow_auxiliary=false no_equations_on_sides=true]
 # Треугольник и заданные углы
 triangle A-B-C
 angle B-A-C [degrees=38]

--- a/tests/integrational/gir/triangle_with_midpoints.gir
+++ b/tests/integrational/gir/triangle_with_midpoints.gir
@@ -3,7 +3,7 @@ scene "Triangle ABC with midline DE and trapezoid ABED"
 layout canonical=triangle_AB_horizontal scale=1
 points A, B, C, D, E
 
-rules [no_solving=true allow_auxiliary=false no_unicode_degree=true mark_right_angles_as_square=true no_equations_on_sides=true]
+rules [no_solving=true allow_auxiliary=false no_equations_on_sides=true]
 
 triangle A-B-C [label="Area=60"]
 point D on segment A-C

--- a/tests/test_tikz_codegen.py
+++ b/tests/test_tikz_codegen.py
@@ -63,12 +63,9 @@ def test_equal_segments_apply_tick_style() -> None:
     assert "tick1" in tikz
 
 
-def test_rules_toggle_right_angle_square() -> None:
+def test_right_angle_marks_render_by_default() -> None:
     program = Program(
-        [
-            Stmt("rules", Span(1, 1), {}, {"mark_right_angles_as_square": True}),
-            Stmt("right_angle_at", Span(2, 1), {"points": ("A", "B", "C")}),
-        ]
+        [Stmt("right_angle_at", Span(1, 1), {"points": ("A", "B", "C")})]
     )
     coords = {"A": (0.0, 1.0), "B": (0.0, 0.0), "C": (1.0, 0.0)}
 
@@ -77,11 +74,10 @@ def test_rules_toggle_right_angle_square() -> None:
     assert "right angle=A--B--C" in tikz
 
 
-def test_no_unicode_degree_rule_forces_circ_symbol() -> None:
+def test_angle_measure_uses_circ_symbol() -> None:
     program = Program(
         [
-            Stmt("rules", Span(1, 1), {}, {"no_unicode_degree": True}),
-            Stmt("angle_at", Span(2, 1), {"points": ("C", "B", "A")}, {"degrees": 30}),
+            Stmt("angle_at", Span(1, 1), {"points": ("C", "B", "A")}, {"degrees": 30}),
         ]
     )
     coords = {"A": (0.0, 1.0), "B": (0.0, 0.0), "C": (1.0, 0.0)}


### PR DESCRIPTION
## Summary
- remove the legacy mark_right_angles_as_square and no_unicode_degree options from validation and rendering
- render right angles with squares and angle measures with ^\circ unconditionally
- refresh docs, tests, and example GIR scenes to match the new always-on behaviour

## Testing
- pytest *(fails: geoscript_ir package not installed in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e573b1f888832790ee2f76d3710605