### PR TITLE
Ensure printer handles foot statements and fails on unknown kinds

### DIFF
--- a/geoscript_ir/printer.py
+++ b/geoscript_ir/printer.py
@@ -1,198 +1,272 @@
+from typing import Dict, Iterable, Tuple
+
 from .ast import Program, Stmt
 from .numbers import SymbolicNumber
-from typing import Tuple
 
-def edge_str(e: Tuple[str,str]) -> str:
-    return f'{e[0]}-{e[1]}'
+
+def edge_str(edge: Tuple[str, str]) -> str:
+    return f"{edge[0]}-{edge[1]}"
+
 
 def angle_str(points: Tuple[str, str, str]) -> str:
-    return f'{points[0]}-{points[1]}-{points[2]}'
+    return f"{points[0]}-{points[1]}-{points[2]}"
+
+
+def _format_opts(opts: Dict[str, object]) -> str:
+    if not opts:
+        return ""
+    parts = []
+    for key in sorted(opts.keys()):
+        value = opts[key]
+        if isinstance(value, bool):
+            rendered = "true" if value else "false"
+        elif isinstance(value, (int, float)):
+            rendered = str(value)
+        elif isinstance(value, SymbolicNumber):
+            rendered = str(value)
+        else:
+            rendered = value if (isinstance(value, str) and " " not in value) else f'"{value}"'
+        parts.append(f"{key}={rendered}")
+    return " [" + " ".join(parts) + "]"
+
+
+def _require_edge(payload: object, *, kind: str) -> Tuple[str, str]:
+    if not isinstance(payload, (list, tuple)) or len(payload) != 2:
+        raise ValueError(f"invalid {kind} payload {payload!r}")
+    a, b = payload
+    if not (isinstance(a, str) and isinstance(b, str)):
+        raise ValueError(f"invalid {kind} payload {payload!r}")
+    return str(a), str(b)
 
 
 def path_str(path: Tuple[str, object]) -> str:
     kind, payload = path
-    if kind in {'line', 'ray', 'segment'} and isinstance(payload, (list, tuple)):
-        return f'{kind} {edge_str(payload)}'
-    if kind == 'circle' and isinstance(payload, str):
-        return f'circle center {payload}'
-    if kind == 'angle-bisector' and isinstance(payload, dict):
-        pts = payload.get('points')
-        extra = ' external' if payload.get('external') else ''
-        if isinstance(pts, (list, tuple)) and len(pts) == 3:
-            return f'angle-bisector {angle_str(tuple(pts))}{extra}'
-        return f'angle-bisector{extra}'
-    if kind == 'perpendicular' and isinstance(payload, dict):
-        at = payload.get('at', '')
-        to_edge = payload.get('to')
-        if isinstance(to_edge, (list, tuple)):
-            return f'perpendicular at {at} to {edge_str(to_edge)}'
-        return f'perpendicular at {at}'
-    if kind == 'median' and isinstance(payload, dict):
-        frm = payload.get('frm', '')
-        to_edge = payload.get('to')
-        if isinstance(to_edge, (list, tuple)):
-            return f'median from {frm} to {edge_str(to_edge)}'
-        return f'median from {frm}'
-    if kind == 'perp-bisector' and isinstance(payload, (list, tuple)):
-        return f'perp-bisector of {edge_str(tuple(payload))}'
-    if kind == 'parallel' and isinstance(payload, dict):
-        through = payload.get('through', '')
-        to_edge = payload.get('to')
-        if isinstance(to_edge, (list, tuple)):
-            return f'parallel through {through} to {edge_str(tuple(to_edge))}'
-        return f'parallel through {through}'
-    return f'# [unknown path {kind}]'
+    if kind in {"line", "ray", "segment"}:
+        return f"{kind} {edge_str(_require_edge(payload, kind=kind))}"
+    if kind == "circle":
+        if not isinstance(payload, str):
+            raise ValueError(f"invalid circle payload {payload!r}")
+        return f"circle center {payload}"
+    if kind == "angle-bisector":
+        if not isinstance(payload, dict):
+            raise ValueError(f"invalid angle-bisector payload {payload!r}")
+        pts = payload.get("points")
+        extra = " external" if payload.get("external") else ""
+        if not isinstance(pts, (list, tuple)) or len(pts) != 3:
+            raise ValueError(f"invalid angle-bisector points {pts!r}")
+        return f"angle-bisector {angle_str(tuple(pts))}{extra}"
+    if kind == "perpendicular":
+        if not isinstance(payload, dict):
+            raise ValueError(f"invalid perpendicular payload {payload!r}")
+        at = payload.get("at")
+        to_edge = payload.get("to")
+        if not isinstance(at, str):
+            raise ValueError(f"invalid perpendicular at-point {at!r}")
+        edge = _require_edge(to_edge, kind="perpendicular to")
+        return f"perpendicular at {at} to {edge_str(edge)}"
+    if kind == "median":
+        if not isinstance(payload, dict):
+            raise ValueError(f"invalid median payload {payload!r}")
+        frm = payload.get("frm")
+        to_edge = payload.get("to")
+        if not isinstance(frm, str):
+            raise ValueError(f"invalid median source {frm!r}")
+        edge = _require_edge(to_edge, kind="median to")
+        return f"median from {frm} to {edge_str(edge)}"
+    if kind == "perp-bisector":
+        edge = _require_edge(payload, kind="perp-bisector")
+        return f"perp-bisector of {edge_str(edge)}"
+    if kind == "parallel":
+        if not isinstance(payload, dict):
+            raise ValueError(f"invalid parallel payload {payload!r}")
+        through = payload.get("through")
+        to_edge = payload.get("to")
+        if not isinstance(through, str):
+            raise ValueError(f"invalid parallel through-point {through!r}")
+        edge = _require_edge(to_edge, kind="parallel to")
+        return f"parallel through {through} to {edge_str(edge)}"
+    raise ValueError(f"unknown path kind {kind!r}")
+
+
+def _edge_chain(ids: Iterable[str]) -> str:
+    return "-".join(ids)
+
 
 def print_program(prog: Program, *, original_only: bool = False) -> str:
     lines = []
-    for s in prog.stmts:
-        if original_only and s.origin != 'source':
+    for stmt in prog.stmts:
+        if original_only and stmt.origin != "source":
             continue
-        o = ''
-        if s.opts:
-            parts = []
-            for k in sorted(s.opts.keys()):
-                v = s.opts[k]
-                if isinstance(v, bool):
-                    vv = 'true' if v else 'false'
-                elif isinstance(v, (int,float)):
-                    vv = str(v)
-                elif isinstance(v, SymbolicNumber):
-                    vv = str(v)
-                else:
-                    vv = v if (isinstance(v,str) and ' ' not in v) else f'"{v}"'
-                parts.append(f'{k}={vv}')
-            o = f' [{" ".join(parts)}]'
-        if s.kind == 'scene':
-            lines.append(f'scene "{s.data["title"]}"')
-        elif s.kind == 'layout':
-            lines.append(f'layout canonical={s.data["canonical"]} scale={s.data["scale"]}')
-        elif s.kind == 'points':
-            lines.append('points ' + ', '.join(s.data['ids']))
-        elif s.kind == 'segment':
-            lines.append(f'segment {edge_str(s.data["edge"])}')
-        elif s.kind == 'ray':
-            lines.append(f'ray {edge_str(s.data["ray"])}')
-        elif s.kind == 'line':
-            lines.append(f'line {edge_str(s.data["edge"])}')
-        elif s.kind == 'line_tangent_at':
-            lines.append(f'line {edge_str(s.data["edge"])} tangent to circle center {s.data["center"]} at {s.data["at"]}{o}'); continue
-        elif s.kind == 'circle_center_radius_through':
-            lines.append(f'circle center {s.data["center"]} radius-through {s.data["through"]}{o}'); continue
-        elif s.kind == 'circle_through':
-            ids = ', '.join(s.data['ids'])
-            lines.append(f'circle through ({ids})')
-        elif s.kind == 'circumcircle':
-            chain = '-'.join(s.data['ids'])
-            lines.append(f'circumcircle of {chain}')
-        elif s.kind == 'incircle':
-            chain = '-'.join(s.data['ids'])
-            lines.append(f'incircle of {chain}')
-        elif s.kind == 'perpendicular_at':
-            lines.append(
-                f'perpendicular at {s.data["at"]} to {edge_str(s.data["to"])} '
-                f'foot {s.data["foot"]}'
+
+        opts_suffix = _format_opts(stmt.opts)
+        line: str
+
+        if stmt.kind == "scene":
+            line = f"scene \"{stmt.data['title']}\""
+        elif stmt.kind == "layout":
+            line = (
+                f"layout canonical={stmt.data['canonical']} "
+                f"scale={stmt.data['scale']}"
             )
-        elif s.kind == 'parallel_through':
-            lines.append(f'parallel through {s.data["through"]} to {edge_str(s.data["to"])}')
-        elif s.kind == 'angle_bisector_at':
-            points = s.data.get('points')
+        elif stmt.kind == "points":
+            line = "points " + ", ".join(stmt.data["ids"])
+        elif stmt.kind == "segment":
+            line = f"segment {edge_str(stmt.data['edge'])}"
+        elif stmt.kind == "ray":
+            line = f"ray {edge_str(stmt.data['ray'])}"
+        elif stmt.kind == "line":
+            line = f"line {edge_str(stmt.data['edge'])}"
+        elif stmt.kind == "line_tangent_at":
+            line = (
+                f"line {edge_str(stmt.data['edge'])} tangent to circle center "
+                f"{stmt.data['center']} at {stmt.data['at']}"
+            )
+        elif stmt.kind == "circle_center_radius_through":
+            line = (
+                f"circle center {stmt.data['center']} radius-through "
+                f"{stmt.data['through']}"
+            )
+        elif stmt.kind == "circle_through":
+            line = "circle through (" + ", ".join(stmt.data["ids"]) + ")"
+        elif stmt.kind == "circumcircle":
+            line = f"circumcircle of {_edge_chain(stmt.data['ids'])}"
+        elif stmt.kind == "incircle":
+            line = f"incircle of {_edge_chain(stmt.data['ids'])}"
+        elif stmt.kind == "perpendicular_at":
+            line = (
+                f"perpendicular at {stmt.data['at']} to {edge_str(stmt.data['to'])} "
+                f"foot {stmt.data['foot']}"
+            )
+        elif stmt.kind == "parallel_through":
+            line = (
+                f"parallel through {stmt.data['through']} to "
+                f"{edge_str(stmt.data['to'])}"
+            )
+        elif stmt.kind == "angle_bisector_at":
+            points = stmt.data.get("points")
             if isinstance(points, (list, tuple)) and len(points) == 3:
-                lines.append(f'angle-bisector {angle_str(tuple(points))}{o}')
+                line = f"angle-bisector {angle_str(tuple(points))}"
             else:
-                r1, r2 = s.data.get('rays', (None, None))
-                if r1 and r2:
-                    lines.append(f'angle-bisector at {s.data.get("at", "")} rays {edge_str(r1)} {edge_str(r2)}{o}')
+                ray1, ray2 = stmt.data.get("rays", (None, None))
+                if ray1 and ray2:
+                    line = (
+                        f"angle-bisector at {stmt.data.get('at', '')} rays "
+                        f"{edge_str(ray1)} {edge_str(ray2)}"
+                    )
                 else:
-                    lines.append(f'angle-bisector{o}')
-            continue
-        elif s.kind == 'median_from_to':
-            lines.append(
-                f'median from {s.data["frm"]} to {edge_str(s.data["to"])} '
-                f'midpoint {s.data["midpoint"]}'
+                    line = "angle-bisector"
+        elif stmt.kind == "median_from_to":
+            line = (
+                f"median from {stmt.data['frm']} to {edge_str(stmt.data['to'])} "
+                f"midpoint {stmt.data['midpoint']}"
             )
-        elif s.kind == 'angle_at':
-            lines.append(f'angle {angle_str(tuple(s.data["points"]))}{o}'); continue
-        elif s.kind == 'right_angle_at':
-            lines.append(f'right-angle {angle_str(tuple(s.data["points"]))}{o}'); continue
-        elif s.kind == 'equal_segments':
-            lhs = ', '.join(edge_str(e) for e in s.data['lhs'])
-            rhs = ', '.join(edge_str(e) for e in s.data['rhs'])
-            lines.append(f'equal-segments ({lhs} ; {rhs})')
-        elif s.kind == 'collinear':
-            ids = ', '.join(s.data['points'])
-            lines.append(f'collinear ({ids})')
-        elif s.kind == 'concyclic':
-            ids = ', '.join(s.data['points'])
-            lines.append(f'concyclic ({ids})')
-        elif s.kind == 'equal_angles':
-            lhs = ', '.join(angle_str(tuple(ang)) for ang in s.data['lhs'])
-            rhs = ', '.join(angle_str(tuple(ang)) for ang in s.data['rhs'])
-            lines.append(f'equal-angles ({lhs} ; {rhs})')
-        elif s.kind == 'ratio':
-            left, right = s.data['edges']
-            a, b = s.data['ratio']
-
-            def _fmt_ratio_part(val):
-                if isinstance(val, float) and val.is_integer():
-                    return str(int(val))
-                return str(val)
-
-            lines.append(
-                f'ratio ({edge_str(left)} : {edge_str(right)} = {_fmt_ratio_part(a)} : {_fmt_ratio_part(b)})'
+        elif stmt.kind == "midpoint":
+            line = (
+                f"midpoint {stmt.data['midpoint']} of "
+                f"{edge_str(stmt.data['edge'])}"
             )
-        elif s.kind == 'tangent_at':
-            lines.append(f'tangent at {s.data["at"]} to circle center {s.data["center"]}{o}'); continue
-        elif s.kind == 'diameter':
-            lines.append(
-                f'diameter {edge_str(s.data["edge"])} to circle center {s.data["center"]}{o}'
-            );
+        elif stmt.kind == "foot":
+            line = (
+                f"foot {stmt.data['foot']} from {stmt.data['from']} to "
+                f"{edge_str(stmt.data['edge'])}"
+            )
+        elif stmt.kind == "angle_at":
+            line = f"angle {angle_str(tuple(stmt.data['points']))}"
+        elif stmt.kind == "right_angle_at":
+            line = f"right-angle {angle_str(tuple(stmt.data['points']))}"
+        elif stmt.kind == "equal_segments":
+            lhs = ", ".join(edge_str(edge) for edge in stmt.data["lhs"])
+            rhs = ", ".join(edge_str(edge) for edge in stmt.data["rhs"])
+            line = f"equal-segments ({lhs} ; {rhs})"
+        elif stmt.kind == "collinear":
+            line = "collinear (" + ", ".join(stmt.data["points"]) + ")"
+        elif stmt.kind == "concyclic":
+            line = "concyclic (" + ", ".join(stmt.data["points"]) + ")"
+        elif stmt.kind == "equal_angles":
+            lhs = ", ".join(angle_str(tuple(ang)) for ang in stmt.data["lhs"])
+            rhs = ", ".join(angle_str(tuple(ang)) for ang in stmt.data["rhs"])
+            line = f"equal-angles ({lhs} ; {rhs})"
+        elif stmt.kind == "ratio":
+            left, right = stmt.data["edges"]
+            a, b = stmt.data["ratio"]
+
+            def _fmt_ratio_part(value: object) -> str:
+                if isinstance(value, float) and value.is_integer():
+                    return str(int(value))
+                return str(value)
+
+            line = (
+                f"ratio ({edge_str(left)} : {edge_str(right)} = "
+                f"{_fmt_ratio_part(a)} : {_fmt_ratio_part(b)})"
+            )
+        elif stmt.kind == "tangent_at":
+            line = (
+                f"tangent at {stmt.data['at']} to circle center "
+                f"{stmt.data['center']}"
+            )
+        elif stmt.kind == "diameter":
+            line = (
+                f"diameter {edge_str(stmt.data['edge'])} to circle center "
+                f"{stmt.data['center']}"
+            )
+        elif stmt.kind == "polygon":
+            line = f"polygon {_edge_chain(stmt.data['ids'])}"
+        elif stmt.kind in {
+            "triangle",
+            "quadrilateral",
+            "parallelogram",
+            "trapezoid",
+            "rectangle",
+            "square",
+            "rhombus",
+        }:
+            line = f"{stmt.kind} {_edge_chain(stmt.data['ids'])}"
+        elif stmt.kind == "point_on":
+            line = f"point {stmt.data['point']} on {path_str(stmt.data['path'])}"
+        elif stmt.kind == "intersect":
+            at2 = f", {stmt.data['at2']}" if stmt.data['at2'] else ""
+            line = (
+                f"intersect ({path_str(stmt.data['path1'])}) with "
+                f"({path_str(stmt.data['path2'])}) at {stmt.data['at']}{at2}"
+            )
+        elif stmt.kind == "label_point":
+            line = f"label point {stmt.data['point']}"
+        elif stmt.kind == "sidelabel":
+            line = f"sidelabel {edge_str(stmt.data['edge'])} \"{stmt.data['text']}\""
+        elif stmt.kind == "target_angle":
+            line = f"target angle {angle_str(tuple(stmt.data['points']))}"
+        elif stmt.kind == "target_length":
+            line = f"target length {edge_str(stmt.data['edge'])}"
+        elif stmt.kind == "target_point":
+            line = f"target point {stmt.data['point']}"
+        elif stmt.kind == "target_circle":
+            line = f"target circle ({stmt.data['text']})"
+        elif stmt.kind == "target_area":
+            line = f"target area ({stmt.data['text']})"
+        elif stmt.kind == "target_arc":
+            line = (
+                f"target arc {stmt.data['A']}-{stmt.data['B']} on circle center "
+                f"{stmt.data['center']}"
+            )
+        elif stmt.kind == "parallel_edges":
+            a, b = stmt.data["edges"]
+            line = f"parallel-edges ({edge_str(a)} ; {edge_str(b)})"
+        elif stmt.kind == "rules":
+            if not stmt.opts:
+                raise ValueError("rules statement requires at least one option")
+            lines.append("rules" + _format_opts(stmt.opts))
             continue
-        elif s.kind == 'polygon':
-            ids = '-'.join(s.data['ids']); lines.append(f'polygon {ids}{o}'); continue
-        elif s.kind in ('triangle','quadrilateral','parallelogram','trapezoid','rectangle','square','rhombus'):
-            ids = '-'.join(s.data['ids']); lines.append(f'{s.kind} {ids}{o}'); continue
-        elif s.kind == 'point_on':
-            lines.append(f'point {s.data["point"]} on {path_str(s.data["path"])}{o}'); continue
-        elif s.kind == 'intersect':
-            second = f', {s.data["at2"]}' if s.data['at2'] else ''
-            lines.append(
-                f'intersect ({path_str(s.data["path1"])}) with ({path_str(s.data["path2"])}) '
-                f'at {s.data["at"]}{second}{o}'
-            );
-            continue
-        elif s.kind == 'label_point':
-            lines.append(f'label point {s.data["point"]}{o}'); continue
-        elif s.kind == 'sidelabel':
-            lines.append(f'sidelabel {edge_str(s.data["edge"])} "{s.data["text"]}"{o}'); continue
-        elif s.kind == 'target_angle':
-            lines.append(f'target angle {angle_str(tuple(s.data["points"]))}{o}'); continue
-        elif s.kind == 'target_length':
-            lines.append(f'target length {edge_str(s.data["edge"])}{o}'); continue
-        elif s.kind == 'target_point':
-            lines.append(f'target point {s.data["point"]}{o}'); continue
-        elif s.kind == 'target_circle':
-            lines.append(f'target circle ({s.data["text"]}){o}'); continue
-        elif s.kind == 'target_area':
-            lines.append(f'target area ({s.data["text"]}){o}'); continue
-        elif s.kind == 'target_arc':
-            lines.append(f'target arc {s.data["A"]}-{s.data["B"]} on circle center {s.data["center"]}{o}'); continue
-        elif s.kind == 'parallel_edges':
-            a, b = s.data['edges']
-            lines.append(f'parallel-edges ({edge_str(a)} ; {edge_str(b)}){o}')
-            continue
-        elif s.kind == 'rules':
-            if not s.opts:
-                raise ValueError('rules statement requires at least one option')
-            parts = [f'{k}={"true" if s.opts[k] else "false"}' for k in sorted(s.opts.keys())]
-            lines.append('rules [' + ' '.join(parts) + ']'); continue
         else:
-            lines.append(f'# [unknown kind {s.kind}]'); continue
-        if o and lines:
-            lines[-1] += o
-    return '\n'.join(lines) + "\n"
+            raise ValueError(f"unknown statement kind {stmt.kind!r}")
+
+        if opts_suffix:
+            line += opts_suffix
+        lines.append(line)
+
+    return "\n".join(lines) + "\n"
 
 
 def format_stmt(stmt: Stmt) -> str:
     """Return a single-line representation of ``stmt``."""
+
     return print_program(Program(stmts=[stmt])).strip()

--- a/main.md
+++ b/main.md
@@ -294,6 +294,7 @@ The validator runs a dry translation to ensure the residual builder can accept t
 * **Core API**:
 
   * `parse_program`, `validate`, `desugar`
+  * `print_program(program, *, original_only=False)` re-serializes the full grammar (including placement primitives like `midpoint` and `foot`). It either prints a faithful statement or raises `ValueError` for unknown/malformed kinds; `format_stmt` is a one-line wrapper for single statements.
   * **Pre-solve planning (default):**
 
     * `plan_derive(program: Program) -> DerivationPlan`

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -1,5 +1,7 @@
 import math
 
+import pytest
+
 from geoscript_ir.ast import Program, Span, Stmt
 from geoscript_ir.numbers import SymbolicNumber
 from geoscript_ir.printer import print_program
@@ -44,3 +46,19 @@ def test_original_only_skips_generated_statements():
     prog = Program([original, generated])
 
     assert print_program(prog, original_only=True) == 'segment A-B\n'
+
+
+def test_midpoint_and_foot_print_primitives():
+    midpoint = Stmt('midpoint', Span(1, 1), {'midpoint': 'M', 'edge': ('A', 'B')})
+    foot = Stmt('foot', Span(2, 1), {'foot': 'H', 'from': 'C', 'edge': ('A', 'B')})
+    prog = Program([midpoint, foot])
+
+    assert print_program(prog) == 'midpoint M of A-B\nfoot H from C to A-B\n'
+
+
+def test_unknown_kind_raises_value_error():
+    stmt = Stmt('mystery', Span(1, 1), {})
+    prog = Program([stmt])
+
+    with pytest.raises(ValueError):
+        print_program(prog)


### PR DESCRIPTION
## Summary
- refactor the GeoScript printer to cover the entire grammar, formatting midpoint/foot placements and raising on unknown statements instead of emitting placeholders
- extend the printer unit tests to cover foot rendering and verify that unsupported statements now raise ValueError
- document the printer guarantees in the main technical specification

## Testing
- pytest tests/test_printer.py

------
https://chatgpt.com/codex/tasks/task_e_68e667b84bbc8327b9156764bad7aef1